### PR TITLE
feat(ai-config): add deletion capability with confirmation dialog

### DIFF
--- a/apps/admin_page/src/components/ai-models/AiModelsTable.test.tsx
+++ b/apps/admin_page/src/components/ai-models/AiModelsTable.test.tsx
@@ -25,6 +25,7 @@ describe('AiModelsTable', () => {
     configs: mockConfigs,
     loading: false,
     onEdit: vi.fn(),
+    onDelete: vi.fn(),
   };
 
   beforeEach(() => {
@@ -79,5 +80,15 @@ describe('AiModelsTable', () => {
     render(<AiModelsTable {...defaultProps} configs={[]} />);
 
     expect(screen.getByText('No configurations defined')).toBeInTheDocument();
+  });
+
+  it('calls onDelete when clicking the delete button', () => {
+    render(<AiModelsTable {...defaultProps} />);
+
+    // Find the trash icons and click their parent button
+    const deleteBtns = screen.getAllByRole('button').filter(btn => btn.querySelector('svg.lucide-trash2'));
+    fireEvent.click(deleteBtns[0]);
+
+    expect(defaultProps.onDelete).toHaveBeenCalledWith(mockConfigs[0]);
   });
 });

--- a/apps/admin_page/src/components/ai-models/AiModelsTable.tsx
+++ b/apps/admin_page/src/components/ai-models/AiModelsTable.tsx
@@ -129,6 +129,8 @@ const AiModelsTable: React.FC<AiModelsTableProps> = ({ configs, loading, onEdit,
                           Modify
                         </Button>
                         <Button
+                          aria-label={`Delete ${config.feature} configuration`}
+                          title="Delete Configuration"
                           onClick={(e) => { e.stopPropagation(); onDelete(config); }}
                           variant="ghost"
                           size="sm"

--- a/apps/admin_page/src/components/ai-models/AiModelsTable.tsx
+++ b/apps/admin_page/src/components/ai-models/AiModelsTable.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
-import { Settings2, Cpu, Sparkles, Edit2 } from 'lucide-react';
+import { Settings2, Cpu, Sparkles, Edit2, Trash2 } from 'lucide-react';
 import Skeleton from '../Skeleton';
 import Button from '../Button';
 import type { AiModelConfig } from '../../services/api';
@@ -28,9 +28,10 @@ interface AiModelsTableProps {
   configs: AiModelConfig[];
   loading: boolean;
   onEdit: (config: AiModelConfig) => void;
+  onDelete: (config: AiModelConfig) => void;
 }
 
-const AiModelsTable: React.FC<AiModelsTableProps> = ({ configs, loading, onEdit }) => {
+const AiModelsTable: React.FC<AiModelsTableProps> = ({ configs, loading, onEdit, onDelete }) => {
   return (
     <motion.div
       variants={container}
@@ -117,15 +118,25 @@ const AiModelsTable: React.FC<AiModelsTableProps> = ({ configs, loading, onEdit 
                       </span>
                     </td>
                     <td className="px-10 py-6 whitespace-nowrap text-right">
-                      <Button
-                        onClick={(e) => { e.stopPropagation(); onEdit(config); }}
-                        variant="ghost"
-                        size="sm"
-                        leftIcon={<Edit2 size={16} />}
-                        className="text-brand-300 hover:text-primary-600 hover:bg-primary-50"
-                      >
-                        Modify
-                      </Button>
+                      <div className="flex items-center justify-end gap-3">
+                        <Button
+                          onClick={(e) => { e.stopPropagation(); onEdit(config); }}
+                          variant="ghost"
+                          size="sm"
+                          leftIcon={<Edit2 size={16} />}
+                          className="text-brand-300 hover:text-primary-600 hover:bg-primary-50"
+                        >
+                          Modify
+                        </Button>
+                        <Button
+                          onClick={(e) => { e.stopPropagation(); onDelete(config); }}
+                          variant="ghost"
+                          size="sm"
+                          className="text-brand-300 hover:text-error-600 hover:bg-error-50 px-2"
+                        >
+                          <Trash2 size={16} />
+                        </Button>
+                      </div>
                     </td>
                   </motion.tr>
                 ))}

--- a/apps/admin_page/src/pages/AiModels.test.tsx
+++ b/apps/admin_page/src/pages/AiModels.test.tsx
@@ -7,7 +7,8 @@ vi.mock('../services/api', () => ({
   aiService: {
     getConfigs: vi.fn(),
     getAvailableModels: vi.fn(),
-    updateConfig: vi.fn()
+    updateConfig: vi.fn(),
+    deleteConfig: vi.fn()
   }
 }));
 
@@ -75,5 +76,35 @@ describe('AiModels', () => {
     fireEvent.click(newBtn);
 
     expect(screen.getByText('Configure Feature')).toBeInTheDocument();
+  });
+
+  it('opens confirmation dialog when delete is clicked and handles successful deletion', async () => {
+    (aiService.getConfigs as Mock).mockResolvedValue([
+      { id: '1', feature: 'test-feature-to-delete', modelId: 'model-1', description: '', isEnabled: true }
+    ]);
+    (aiService.getAvailableModels as Mock).mockResolvedValue([]);
+    (aiService.deleteConfig as Mock).mockResolvedValue(undefined);
+
+    render(<AiModels />);
+
+    await waitFor(() => {
+      expect(screen.getByText('test-feature-to-delete')).toBeInTheDocument();
+    });
+
+    const deleteBtns = screen.getAllByRole('button').filter(btn => btn.querySelector('svg.lucide-trash2'));
+    fireEvent.click(deleteBtns[0]);
+
+    await waitFor(() => {
+        expect(screen.getByText('Delete AI Configuration')).toBeInTheDocument();
+        expect(screen.getByText(/Are you sure you want to delete the configuration for the feature/)).toBeInTheDocument();
+    });
+
+    const confirmDeleteBtn = screen.getByRole('button', { name: 'Delete' });
+    fireEvent.click(confirmDeleteBtn);
+
+    await waitFor(() => {
+        expect(aiService.deleteConfig).toHaveBeenCalledWith('1');
+        expect(aiService.getConfigs).toHaveBeenCalledTimes(2); // Initial load + reload
+    });
   });
 });

--- a/apps/admin_page/src/pages/AiModels.tsx
+++ b/apps/admin_page/src/pages/AiModels.tsx
@@ -6,6 +6,7 @@ import { Plus } from 'lucide-react';
 import { AnimatePresence } from 'framer-motion';
 import AiModelsTable from '../components/ai-models/AiModelsTable';
 import EditAiModelModal from '../components/ai-models/EditAiModelModal';
+import ConfirmationDialog from '../components/ConfirmationDialog';
 
 const AiModels: React.FC = () => {
   const [configs, setConfigs] = useState<AiModelConfig[]>([]);
@@ -14,6 +15,10 @@ const AiModels: React.FC = () => {
   const [editingConfig, setEditingConfig] = useState<AiModelConfig | null>(null);
   const [isSaving, setIsSaving] = useState(false);
   const [modelSort, setModelSort] = useState<SortOption>('name');
+  const [deleteConfirmation, setDeleteConfirmation] = useState<{ isOpen: boolean; config: AiModelConfig | null }>({
+    isOpen: false,
+    config: null,
+  });
 
   useEffect(() => {
     loadData();
@@ -53,6 +58,24 @@ const AiModels: React.FC = () => {
 
   const handleEdit = (config: AiModelConfig) => {
     setEditingConfig({ ...config });
+  };
+
+  const handleDeleteClick = (config: AiModelConfig) => {
+    setDeleteConfirmation({ isOpen: true, config });
+  };
+
+  const confirmDelete = async () => {
+    if (!deleteConfirmation.config?.id) return;
+    try {
+      await aiService.deleteConfig(deleteConfirmation.config.id);
+      showToast('Configuration deleted successfully.', 'success');
+      setDeleteConfirmation({ isOpen: false, config: null });
+      loadData();
+    } catch (error) {
+      console.error(error);
+      showToast('Failed to delete configuration.', 'error');
+      setDeleteConfirmation({ isOpen: false, config: null });
+    }
   };
 
   const handleSave = async () => {
@@ -107,6 +130,7 @@ const AiModels: React.FC = () => {
         configs={configs}
         loading={loading}
         onEdit={handleEdit}
+        onDelete={handleDeleteClick}
       />
 
       {/* Edit Modal */}
@@ -124,6 +148,16 @@ const AiModels: React.FC = () => {
           />
         )}
       </AnimatePresence>
+
+      <ConfirmationDialog
+        isOpen={deleteConfirmation.isOpen}
+        onClose={() => setDeleteConfirmation({ isOpen: false, config: null })}
+        onConfirm={confirmDelete}
+        title="Delete AI Configuration"
+        message={`Are you sure you want to delete the configuration for the feature "${deleteConfirmation.config?.feature}"? This action cannot be undone.`}
+        confirmLabel="Delete"
+        isDestructive
+      />
     </div>
   );
 };

--- a/apps/admin_page/src/pages/AiModels.tsx
+++ b/apps/admin_page/src/pages/AiModels.tsx
@@ -70,7 +70,7 @@ const AiModels: React.FC = () => {
       await aiService.deleteConfig(deleteConfirmation.config.id);
       showToast('Configuration deleted successfully.', 'success');
       setDeleteConfirmation({ isOpen: false, config: null });
-      loadData();
+      await loadData();
     } catch (error) {
       console.error(error);
       showToast('Failed to delete configuration.', 'error');

--- a/apps/admin_page/src/services/api.ts
+++ b/apps/admin_page/src/services/api.ts
@@ -245,6 +245,9 @@ export const aiService = {
     const response = await api.put<AiModelConfig>(`/ai/config/${feature}`, dto);
     return response.data;
   },
+  deleteConfig: async (id: string): Promise<void> => {
+    await api.delete(`/ai/config/${id}`);
+  },
   getAvailableModels: async (): Promise<AiModel[]> => {
     const response = await api.get<AiModel[]>('/ai/config/models');
     return response.data;

--- a/backend/Valora.Api/Endpoints/AiEndpoints.cs
+++ b/backend/Valora.Api/Endpoints/AiEndpoints.cs
@@ -153,6 +153,11 @@ public static class AiEndpoints
             CancellationToken ct) =>
         {
             var userId = user.FindFirstValue(ClaimTypes.NameIdentifier);
+            if (string.IsNullOrEmpty(userId))
+            {
+                return Results.Unauthorized();
+            }
+
             var deleted = await aiModelService.DeleteConfigAsync(id, ct);
 
             if (!deleted)

--- a/backend/Valora.Api/Endpoints/AiEndpoints.cs
+++ b/backend/Valora.Api/Endpoints/AiEndpoints.cs
@@ -153,7 +153,14 @@ public static class AiEndpoints
             CancellationToken ct) =>
         {
             var userId = user.FindFirstValue(ClaimTypes.NameIdentifier);
-            await aiModelService.DeleteConfigAsync(id, ct);
+            var deleted = await aiModelService.DeleteConfigAsync(id, ct);
+
+            if (!deleted)
+            {
+                logger.LogInformation("User {UserId} attempted to delete non-existent AI config with ID {ConfigId}", userId, id);
+                return Results.NotFound();
+            }
+
             logger.LogWarning("AUDIT: User {UserId} DELETED AI config with ID {ConfigId}",
                 userId, id);
             return Results.NoContent();

--- a/backend/Valora.Api/Endpoints/AiEndpoints.cs
+++ b/backend/Valora.Api/Endpoints/AiEndpoints.cs
@@ -144,5 +144,19 @@ public static class AiEndpoints
             }
         })
         .AddEndpointFilter<Valora.Api.Filters.ValidationFilter<UpdateAiModelConfigDto>>();
+
+        configGroup.MapDelete("/{id:guid}", async (
+            Guid id,
+            IAiModelService aiModelService,
+            ClaimsPrincipal user,
+            ILogger<AiModelConfigDto> logger,
+            CancellationToken ct) =>
+        {
+            var userId = user.FindFirstValue(ClaimTypes.NameIdentifier);
+            await aiModelService.DeleteConfigAsync(id, ct);
+            logger.LogWarning("AUDIT: User {UserId} DELETED AI config with ID {ConfigId}",
+                userId, id);
+            return Results.NoContent();
+        });
     }
 }

--- a/backend/Valora.Application/Common/Interfaces/IAiModelService.cs
+++ b/backend/Valora.Application/Common/Interfaces/IAiModelService.cs
@@ -8,6 +8,6 @@ public interface IAiModelService
     Task<IEnumerable<AiModelConfigDto>> GetAllConfigsAsync(CancellationToken cancellationToken = default);
     Task<AiModelConfigDto> CreateConfigAsync(AiModelConfigDto configDto, CancellationToken cancellationToken = default);
     Task<AiModelConfigDto> UpdateConfigAsync(AiModelConfigDto configDto, CancellationToken cancellationToken = default);
-    Task DeleteConfigAsync(Guid id, CancellationToken cancellationToken = default);
+    Task<bool> DeleteConfigAsync(Guid id, CancellationToken cancellationToken = default);
     Task<string> GetModelForFeatureAsync(string feature, CancellationToken cancellationToken = default);
 }

--- a/backend/Valora.Infrastructure/Services/AiModelService.cs
+++ b/backend/Valora.Infrastructure/Services/AiModelService.cs
@@ -73,14 +73,16 @@ public class AiModelService : IAiModelService
         return MapToDto(config);
     }
 
-    public async Task DeleteConfigAsync(Guid id, CancellationToken cancellationToken = default)
+    public async Task<bool> DeleteConfigAsync(Guid id, CancellationToken cancellationToken = default)
     {
         var config = await _context.AiModelConfigs.FindAsync(new object[] { id }, cancellationToken);
         if (config != null)
         {
             _context.AiModelConfigs.Remove(config);
             await _context.SaveChangesAsync(cancellationToken);
+            return true;
         }
+        return false;
     }
 
     public async Task<string> GetModelForFeatureAsync(string feature, CancellationToken cancellationToken = default)

--- a/backend/Valora.UnitTests/Services/AiModelServiceTests.cs
+++ b/backend/Valora.UnitTests/Services/AiModelServiceTests.cs
@@ -160,7 +160,7 @@ public class AiModelServiceTests : IDisposable
     }
 
     [Fact]
-    public async Task DeleteConfigAsync_RemovesConfig()
+    public async Task DeleteConfigAsync_RemovesConfig_AndReturnsTrue()
     {
         var config = new AiModelConfig
         {
@@ -171,10 +171,21 @@ public class AiModelServiceTests : IDisposable
         _context.AiModelConfigs.Add(config);
         await _context.SaveChangesAsync();
 
-        await _service.DeleteConfigAsync(config.Id);
+        var result = await _service.DeleteConfigAsync(config.Id);
 
+        Assert.True(result);
         var dbConfig = await _context.AiModelConfigs.FirstOrDefaultAsync(c => c.Feature == "delete-feature");
         Assert.Null(dbConfig);
+    }
+
+    [Fact]
+    public async Task DeleteConfigAsync_ReturnsFalse_WhenNotFound()
+    {
+        var nonExistentId = Guid.NewGuid();
+
+        var result = await _service.DeleteConfigAsync(nonExistentId);
+
+        Assert.False(result);
     }
 
     [Fact]

--- a/fix_pr_comments.sh
+++ b/fix_pr_comments.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-# Fix 1: Add aria-label and title to Trash2 button in AiModelsTable.tsx
-sed -i 's/<Button/<Button\n                          aria-label={`Delete ${config.feature} configuration`}\n                          title="Delete Configuration"/g' apps/admin_page/src/components/ai-models/AiModelsTable.tsx
-# Clean up duplicate <Button tags if sed matched too many
-sed -i '/<Button/!b;n;/aria-label=/!b;n;/title=/!b' apps/admin_page/src/components/ai-models/AiModelsTable.tsx # This is tricky with sed, let's use python or diff instead

--- a/fix_pr_comments.sh
+++ b/fix_pr_comments.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# Fix 1: Add aria-label and title to Trash2 button in AiModelsTable.tsx
+sed -i 's/<Button/<Button\n                          aria-label={`Delete ${config.feature} configuration`}\n                          title="Delete Configuration"/g' apps/admin_page/src/components/ai-models/AiModelsTable.tsx
+# Clean up duplicate <Button tags if sed matched too many
+sed -i '/<Button/!b;n;/aria-label=/!b;n;/title=/!b' apps/admin_page/src/components/ai-models/AiModelsTable.tsx # This is tricky with sed, let's use python or diff instead


### PR DESCRIPTION
This change takes the "basic" AI configuration management feature and makes it "complete" by providing full CRUD operations, specifically adding the ability to safely delete AI model configurations from the admin page. It introduces a confirmation dialog to guard the destructive action and updates both the frontend service layer and backend API routing to support the entity's removal. This enhances the depth and polish of the application's administrative capabilities.

---
*PR created automatically by Jules for task [3196782984518750114](https://jules.google.com/task/3196782984518750114) started by @YKDBontekoe*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Delete AI model configurations from the admin UI with a confirmation dialog; successful deletion shows feedback and refreshes the list.

* **Tests**
  * Added test coverage for the delete flow, including confirmation handling and data reload.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->