### PR TITLE
fix: expose missing GetSavedProperties API endpoint

### DIFF
--- a/backend/Valora.Api/Endpoints/WorkspaceEndpoints.cs
+++ b/backend/Valora.Api/Endpoints/WorkspaceEndpoints.cs
@@ -27,6 +27,7 @@ public static class WorkspaceEndpoints
 
         group.MapDelete("/{id}/members/{memberId}", RemoveMember);
 
+        group.MapGet("/{id}/properties", GetSavedProperties);
         group.MapPost("/{id}/properties", SaveProperty)
             .AddEndpointFilter<Valora.Api.Filters.ValidationFilter<SavePropertyDto>>();
 


### PR DESCRIPTION
Mapped `GetSavedProperties` to `GET /api/workspaces/{id}/properties` to fix a bug where properties couldn't be retrieved.

---
*PR created automatically by Jules for task [5935603935152250588](https://jules.google.com/task/5935603935152250588) started by @YKDBontekoe*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new API endpoint to retrieve saved properties associated with workspaces, providing developers with additional data access capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->