### PR TITLE
Refactor flutter app folder structure to group related screens and widgets

### DIFF
--- a/apps/flutter_app/lib/main.dart
+++ b/apps/flutter_app/lib/main.dart
@@ -12,7 +12,7 @@ import 'providers/theme_provider.dart';
 import 'providers/insights_provider.dart';
 import 'providers/ai_chat_provider.dart';
 import 'services/ai_service.dart';
-import 'screens/startup_screen.dart';
+import 'screens/startup/startup_screen.dart';
 import 'services/api_client.dart';
 import 'services/auth_service.dart';
 import 'services/crash_reporting_service.dart';
@@ -22,7 +22,7 @@ import 'repositories/map_repository.dart';
 import 'repositories/notification_repository.dart';
 import 'repositories/context_report_repository.dart';
 import 'repositories/workspace_repository.dart';
-import 'widgets/global_error_widget.dart';
+import 'widgets/common/global_error_widget.dart';
 
 // coverage:ignore-start
 Future<void> main() async {

--- a/apps/flutter_app/lib/screens/auth/auth_wrapper.dart
+++ b/apps/flutter_app/lib/screens/auth/auth_wrapper.dart
@@ -1,8 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
-import '../providers/auth_provider.dart';
-import 'auth/login_screen.dart';
-import 'home_screen.dart';
+import '../../providers/auth_provider.dart';
+import 'login_screen.dart';
+import '../home/home_screen.dart';
 
 class AuthWrapper extends StatelessWidget {
   const AuthWrapper({super.key});

--- a/apps/flutter_app/lib/screens/context_report/context_report_screen.dart
+++ b/apps/flutter_app/lib/screens/context_report/context_report_screen.dart
@@ -9,7 +9,7 @@ import '../../core/theme/valora_colors.dart';
 import 'layouts/search_layout.dart';
 import 'layouts/report_layout.dart';
 import 'layouts/comparison_layout.dart';
-import '../../widgets/valora_error_state.dart';
+import '../../widgets/common/valora_error_state.dart';
 
 class ContextReportScreen extends StatefulWidget {
   const ContextReportScreen({super.key, this.pdokService, this.onFabChanged});

--- a/apps/flutter_app/lib/screens/home/home_screen.dart
+++ b/apps/flutter_app/lib/screens/home/home_screen.dart
@@ -1,14 +1,14 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
-import '../providers/workspace_provider.dart';
-import '../repositories/workspace_repository.dart';
-import '../services/notification_service.dart';
-import '../widgets/home/home_bottom_nav_bar.dart';
-import 'context_report/context_report_screen.dart';
-import 'insights/insights_screen.dart';
-import 'notifications_screen.dart';
-import 'settings_screen.dart';
+import '../../providers/workspace_provider.dart';
+import '../../repositories/workspace_repository.dart';
+import '../../services/notification_service.dart';
+import '../../widgets/home/home_bottom_nav_bar.dart';
+import '../context_report/context_report_screen.dart';
+import '../insights/insights_screen.dart';
+import '../notifications/notifications_screen.dart';
+import '../settings/settings_screen.dart';
 
 class HomeScreen extends StatefulWidget {
   const HomeScreen({super.key});

--- a/apps/flutter_app/lib/screens/notifications/notifications_screen.dart
+++ b/apps/flutter_app/lib/screens/notifications/notifications_screen.dart
@@ -1,13 +1,13 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
-import '../core/theme/valora_colors.dart';
-import '../core/theme/valora_typography.dart';
-import '../core/theme/valora_spacing.dart';
-import '../models/notification.dart';
-import '../services/notification_service.dart';
-import '../widgets/valora_widgets.dart';
-import '../widgets/notifications/notification_card.dart';
+import '../../core/theme/valora_colors.dart';
+import '../../core/theme/valora_typography.dart';
+import '../../core/theme/valora_spacing.dart';
+import '../../models/notification.dart';
+import '../../services/notification_service.dart';
+import '../../widgets/valora_widgets.dart';
+import '../../widgets/notifications/notification_card.dart';
 
 class NotificationsScreen extends StatefulWidget {
   const NotificationsScreen({super.key});

--- a/apps/flutter_app/lib/screens/saved_listings/saved_listing_detail_screen.dart
+++ b/apps/flutter_app/lib/screens/saved_listings/saved_listing_detail_screen.dart
@@ -1,13 +1,13 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
-import '../core/theme/valora_colors.dart';
-import '../core/theme/valora_typography.dart';
-import '../core/theme/valora_spacing.dart';
-import '../models/saved_property.dart';
-import '../models/comment.dart';
-import '../providers/workspace_provider.dart';
-import '../widgets/valora_widgets.dart';
-import '../widgets/workspaces/comment_thread_widget.dart';
+import '../../core/theme/valora_colors.dart';
+import '../../core/theme/valora_typography.dart';
+import '../../core/theme/valora_spacing.dart';
+import '../../models/saved_property.dart';
+import '../../models/comment.dart';
+import '../../providers/workspace_provider.dart';
+import '../../widgets/valora_widgets.dart';
+import '../../widgets/workspaces/comment_thread_widget.dart';
 
 class SavedListingDetailScreen extends StatefulWidget {
   final SavedProperty savedListing;

--- a/apps/flutter_app/lib/screens/settings/settings_screen.dart
+++ b/apps/flutter_app/lib/screens/settings/settings_screen.dart
@@ -1,14 +1,14 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:url_launcher/url_launcher.dart';
-import 'workspace_list_screen.dart';
-import '../core/theme/valora_colors.dart';
-import '../core/theme/valora_typography.dart';
-import '../core/theme/valora_spacing.dart';
-import '../providers/theme_provider.dart';
-import '../providers/auth_provider.dart';
-import '../providers/workspace_provider.dart';
-import '../widgets/valora_widgets.dart';
+import '../workspaces/workspace_list_screen.dart';
+import '../../core/theme/valora_colors.dart';
+import '../../core/theme/valora_typography.dart';
+import '../../core/theme/valora_spacing.dart';
+import '../../providers/theme_provider.dart';
+import '../../providers/auth_provider.dart';
+import '../../providers/workspace_provider.dart';
+import '../../widgets/valora_widgets.dart';
 
 class SettingsScreen extends StatelessWidget {
   const SettingsScreen({super.key});

--- a/apps/flutter_app/lib/screens/startup/startup_screen.dart
+++ b/apps/flutter_app/lib/screens/startup/startup_screen.dart
@@ -2,9 +2,9 @@ import 'dart:async';
 
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
-import '../providers/auth_provider.dart';
-import 'auth_wrapper.dart';
-import '../widgets/valora_error_state.dart';
+import '../../providers/auth_provider.dart';
+import '../auth/auth_wrapper.dart';
+import '../../widgets/common/valora_error_state.dart';
 
 class StartupScreen extends StatefulWidget {
   const StartupScreen({super.key});

--- a/apps/flutter_app/lib/screens/workspaces/workspace_detail_screen.dart
+++ b/apps/flutter_app/lib/screens/workspaces/workspace_detail_screen.dart
@@ -1,17 +1,17 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
-import '../core/theme/valora_colors.dart';
-import '../core/theme/valora_typography.dart';
-import '../core/theme/valora_spacing.dart';
-import '../providers/workspace_provider.dart';
-import '../providers/context_report_provider.dart';
-import '../screens/context_report/context_report_screen.dart';
-import '../widgets/valora_widgets.dart';
-import '../widgets/workspaces/activity_feed_widget.dart';
-import '../models/activity_log.dart';
-import '../models/workspace.dart';
-import '../models/saved_property.dart';
-import '../widgets/workspaces/member_management_widget.dart';
+import '../../core/theme/valora_colors.dart';
+import '../../core/theme/valora_typography.dart';
+import '../../core/theme/valora_spacing.dart';
+import '../../providers/workspace_provider.dart';
+import '../../providers/context_report_provider.dart';
+import '../../screens/context_report/context_report_screen.dart';
+import '../../widgets/valora_widgets.dart';
+import '../../widgets/workspaces/activity_feed_widget.dart';
+import '../../models/activity_log.dart';
+import '../../models/workspace.dart';
+import '../../models/saved_property.dart';
+import '../../widgets/workspaces/member_management_widget.dart';
 
 class WorkspaceDetailScreen extends StatefulWidget {
   final String workspaceId;

--- a/apps/flutter_app/lib/screens/workspaces/workspace_list_screen.dart
+++ b/apps/flutter_app/lib/screens/workspaces/workspace_list_screen.dart
@@ -1,12 +1,12 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
-import '../core/theme/valora_colors.dart';
-import '../core/theme/valora_typography.dart';
-import '../core/theme/valora_spacing.dart';
-import '../models/workspace.dart';
-import '../providers/workspace_provider.dart';
-import '../widgets/valora_widgets.dart';
-import '../widgets/workspaces/workspace_list_item.dart';
+import '../../core/theme/valora_colors.dart';
+import '../../core/theme/valora_typography.dart';
+import '../../core/theme/valora_spacing.dart';
+import '../../models/workspace.dart';
+import '../../providers/workspace_provider.dart';
+import '../../widgets/valora_widgets.dart';
+import '../../widgets/workspaces/workspace_list_item.dart';
 
 enum SortOption { name, createdDate, memberCount }
 

--- a/apps/flutter_app/lib/widgets/common/global_error_widget.dart
+++ b/apps/flutter_app/lib/widgets/common/global_error_widget.dart
@@ -1,9 +1,9 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-import '../core/theme/valora_spacing.dart';
-import '../core/theme/valora_typography.dart';
-import '../screens/startup_screen.dart';
+import '../../core/theme/valora_spacing.dart';
+import '../../core/theme/valora_typography.dart';
+import '../../screens/startup/startup_screen.dart';
 
 class GlobalErrorWidget extends StatelessWidget {
   final FlutterErrorDetails details;

--- a/apps/flutter_app/lib/widgets/common/valora_error_state.dart
+++ b/apps/flutter_app/lib/widgets/common/valora_error_state.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
-import '../core/exceptions/app_exceptions.dart';
-import 'valora_widgets.dart';
+import '../../core/exceptions/app_exceptions.dart';
+import '../valora_widgets.dart';
 
 class ValoraErrorState extends StatelessWidget {
   final Object error;

--- a/apps/flutter_app/lib/widgets/common/valora_glass_container.dart
+++ b/apps/flutter_app/lib/widgets/common/valora_glass_container.dart
@@ -1,7 +1,7 @@
 import 'dart:ui';
 import 'package:flutter/material.dart';
-import '../core/theme/valora_colors.dart';
-import '../core/theme/valora_spacing.dart';
+import '../../core/theme/valora_colors.dart';
+import '../../core/theme/valora_spacing.dart';
 
 /// A premium glassmorphism container with backdrop blur and subtle borders.
 ///

--- a/apps/flutter_app/lib/widgets/home/home_bottom_nav_bar.dart
+++ b/apps/flutter_app/lib/widgets/home/home_bottom_nav_bar.dart
@@ -8,7 +8,7 @@ import '../../core/theme/valora_typography.dart';
 import '../../core/theme/valora_animations.dart';
 import '../../core/theme/valora_shadows.dart';
 import '../../services/notification_service.dart';
-import '../valora_glass_container.dart';
+import '../common/valora_glass_container.dart';
 
 class HomeBottomNavBar extends StatelessWidget {
   final int currentIndex;

--- a/apps/flutter_app/lib/widgets/home/home_header.dart
+++ b/apps/flutter_app/lib/widgets/home/home_header.dart
@@ -6,7 +6,7 @@ import '../../core/theme/valora_spacing.dart';
 import '../../core/theme/valora_typography.dart';
 import '../../core/theme/valora_animations.dart';
 import '../../core/theme/valora_shadows.dart';
-import '../valora_glass_container.dart';
+import '../common/valora_glass_container.dart';
 import '../common/valora_chip.dart';
 
 class HomeHeader extends StatefulWidget {

--- a/apps/flutter_app/lib/widgets/notifications/notification_card.dart
+++ b/apps/flutter_app/lib/widgets/notifications/notification_card.dart
@@ -7,7 +7,7 @@ import '../../core/theme/valora_spacing.dart';
 import '../../models/notification.dart';
 import '../../services/notification_service.dart';
 import '../../widgets/valora_widgets.dart';
-import '../../screens/workspace_detail_screen.dart';
+import '../../screens/workspaces/workspace_detail_screen.dart';
 import '../../screens/context_report/context_report_screen.dart';
 
 class NotificationCard extends StatelessWidget {

--- a/apps/flutter_app/lib/widgets/report/context_report_view.dart
+++ b/apps/flutter_app/lib/widgets/report/context_report_view.dart
@@ -4,7 +4,7 @@ import 'package:flutter_animate/flutter_animate.dart';
 
 import '../../models/context_report.dart';
 import '../../providers/context_report_provider.dart';
-import '../valora_glass_container.dart';
+import '../common/valora_glass_container.dart';
 import '../../core/theme/valora_typography.dart';
 import '../../core/theme/valora_colors.dart';
 import 'ai_insight_card.dart';

--- a/apps/flutter_app/lib/widgets/report/smart_insights_grid.dart
+++ b/apps/flutter_app/lib/widgets/report/smart_insights_grid.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import '../../models/context_report.dart';
-import '../valora_glass_container.dart';
+import '../common/valora_glass_container.dart';
 
 class SmartInsightsGrid extends StatelessWidget {
   const SmartInsightsGrid({super.key, required this.report});

--- a/apps/flutter_app/lib/widgets/valora_widgets.dart
+++ b/apps/flutter_app/lib/widgets/valora_widgets.dart
@@ -14,3 +14,6 @@ export 'common/valora_avatar.dart';
 export 'common/valora_search_field.dart';
 export 'common/valora_slider.dart';
 export 'common/valora_section_header.dart';
+export 'common/valora_glass_container.dart';
+export 'common/global_error_widget.dart';
+export 'common/valora_error_state.dart';

--- a/apps/flutter_app/lib/widgets/workspaces/workspace_list_item.dart
+++ b/apps/flutter_app/lib/widgets/workspaces/workspace_list_item.dart
@@ -7,7 +7,7 @@ import '../../core/theme/valora_spacing.dart';
 import '../../models/workspace.dart';
 import '../../providers/workspace_provider.dart';
 import '../../widgets/valora_widgets.dart';
-import '../../screens/workspace_detail_screen.dart';
+import '../../screens/workspaces/workspace_detail_screen.dart';
 
 class WorkspaceListItem extends StatelessWidget {
   final Workspace workspace;

--- a/apps/flutter_app/test/screens/notifications_screen_test.dart
+++ b/apps/flutter_app/test/screens/notifications_screen_test.dart
@@ -4,7 +4,7 @@ import 'package:mockito/annotations.dart';
 import 'package:mockito/mockito.dart';
 import 'package:provider/provider.dart';
 import 'package:valora_app/models/notification.dart';
-import 'package:valora_app/screens/notifications_screen.dart';
+import 'package:valora_app/screens/notifications/notifications_screen.dart';
 import 'package:valora_app/services/notification_service.dart';
 import 'package:valora_app/widgets/valora_widgets.dart';
 

--- a/apps/flutter_app/test/screens/settings_screen_test.dart
+++ b/apps/flutter_app/test/screens/settings_screen_test.dart
@@ -6,7 +6,7 @@ import 'package:mockito/mockito.dart';
 import 'package:provider/provider.dart';
 import 'package:valora_app/providers/auth_provider.dart';
 import 'package:valora_app/providers/theme_provider.dart';
-import 'package:valora_app/screens/settings_screen.dart';
+import 'package:valora_app/screens/settings/settings_screen.dart';
 
 @GenerateMocks([AuthProvider, ThemeProvider])
 @GenerateNiceMocks([

--- a/apps/flutter_app/test/screens/startup_screen_test.dart
+++ b/apps/flutter_app/test/screens/startup_screen_test.dart
@@ -2,8 +2,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:provider/provider.dart';
 import 'package:valora_app/providers/auth_provider.dart';
-import 'package:valora_app/screens/startup_screen.dart';
-import 'package:valora_app/widgets/valora_error_state.dart';
+import 'package:valora_app/screens/startup/startup_screen.dart';
+import 'package:valora_app/widgets/common/valora_error_state.dart';
 
 class DelayedAuthProvider extends ChangeNotifier implements AuthProvider {
   DelayedAuthProvider({required this.delay});

--- a/apps/flutter_app/test/screens/workspace_detail_screen_test.dart
+++ b/apps/flutter_app/test/screens/workspace_detail_screen_test.dart
@@ -6,7 +6,7 @@ import 'package:valora_app/models/workspace.dart';
 import 'package:valora_app/models/saved_property.dart';
 import 'package:valora_app/models/activity_log.dart';
 import 'package:valora_app/providers/workspace_provider.dart';
-import 'package:valora_app/screens/workspace_detail_screen.dart';
+import 'package:valora_app/screens/workspaces/workspace_detail_screen.dart';
 
 // Mock Provider
 class MockWorkspaceProvider extends Mock implements WorkspaceProvider {

--- a/apps/flutter_app/test/screens/workspace_list_screen_test.dart
+++ b/apps/flutter_app/test/screens/workspace_list_screen_test.dart
@@ -6,7 +6,7 @@ import 'package:valora_app/models/saved_property.dart';
 import 'package:valora_app/models/activity_log.dart';
 import 'package:valora_app/models/comment.dart';
 import 'package:valora_app/providers/workspace_provider.dart';
-import 'package:valora_app/screens/workspace_list_screen.dart';
+import 'package:valora_app/screens/workspaces/workspace_list_screen.dart';
 
 class FakeWorkspaceProvider extends ChangeNotifier implements WorkspaceProvider {
   bool _isWorkspacesLoading = false;

--- a/apps/flutter_app/test/widgets/global_error_widget_test.dart
+++ b/apps/flutter_app/test/widgets/global_error_widget_test.dart
@@ -1,8 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:provider/provider.dart';
-import 'package:valora_app/widgets/global_error_widget.dart';
-import 'package:valora_app/screens/startup_screen.dart';
+import 'package:valora_app/widgets/common/global_error_widget.dart';
+import 'package:valora_app/screens/startup/startup_screen.dart';
 import 'package:valora_app/providers/auth_provider.dart';
 
 // Fake AuthProvider to satisfy StartupScreen dependency

--- a/apps/flutter_app/test/widgets/valora_error_state_test.dart
+++ b/apps/flutter_app/test/widgets/valora_error_state_test.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:valora_app/core/exceptions/app_exceptions.dart';
-import 'package:valora_app/widgets/valora_error_state.dart';
+import 'package:valora_app/widgets/common/valora_error_state.dart';
 
 void main() {
   group('ValoraErrorState', () {

--- a/apps/flutter_app/test/widgets/workspaces/workspace_detail_screen_test.dart
+++ b/apps/flutter_app/test/widgets/workspaces/workspace_detail_screen_test.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:provider/provider.dart';
 import 'package:valora_app/providers/workspace_provider.dart';
-import 'package:valora_app/screens/workspace_detail_screen.dart';
+import 'package:valora_app/screens/workspaces/workspace_detail_screen.dart';
 import 'package:valora_app/models/workspace.dart';
 import 'package:valora_app/models/saved_property.dart';
 import 'package:valora_app/models/activity_log.dart';

--- a/apps/flutter_app/test/widgets/workspaces/workspace_list_screen_test.dart
+++ b/apps/flutter_app/test/widgets/workspaces/workspace_list_screen_test.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:provider/provider.dart';
 import 'package:valora_app/providers/workspace_provider.dart';
-import 'package:valora_app/screens/workspace_list_screen.dart';
+import 'package:valora_app/screens/workspaces/workspace_list_screen.dart';
 import 'package:valora_app/models/workspace.dart';
 import 'package:valora_app/models/saved_property.dart';
 import 'package:valora_app/models/activity_log.dart';


### PR DESCRIPTION
Organized the Flutter app screen files by grouping them into domain-specific directories (`home/`, `startup/`, `workspaces/`, `settings/`, `notifications/`, `saved_listings/`) to clean up the `lib/screens/` root. Similarly grouped general-purpose, unstructured widgets (`valora_glass_container.dart`, `global_error_widget.dart`, `valora_error_state.dart`) into `lib/widgets/common/`. Adjusted all relative and absolute imports accordingly across lib and test files, ensuring 100% pass on `flutter test` and `flutter analyze`.

---
*PR created automatically by Jules for task [2620080571908909177](https://jules.google.com/task/2620080571908909177) started by @YKDBontekoe*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized project structure for improved code organization and maintainability across screens and widgets.

* **Tests**
  * Updated test files to reflect the restructured project layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->