### PR TITLE
Refactor: Enforce Clean Architecture interface boundaries

### DIFF
--- a/backend/Valora.Api/Endpoints/NotificationEndpoints.cs
+++ b/backend/Valora.Api/Endpoints/NotificationEndpoints.cs
@@ -1,7 +1,6 @@
 using System.Security.Claims;
 using Microsoft.AspNetCore.Mvc;
 using Valora.Application.Common.Interfaces;
-using Valora.Application.Services;
 using Valora.Domain.Enums;
 
 namespace Valora.Api.Endpoints;

--- a/backend/Valora.Api/Endpoints/NotificationEndpoints.cs
+++ b/backend/Valora.Api/Endpoints/NotificationEndpoints.cs
@@ -1,5 +1,6 @@
 using System.Security.Claims;
 using Microsoft.AspNetCore.Mvc;
+using Valora.Application.Common.Interfaces;
 using Valora.Application.Services;
 using Valora.Domain.Enums;
 

--- a/backend/Valora.Application/Common/Interfaces/IBatchJobProcessor.cs
+++ b/backend/Valora.Application/Common/Interfaces/IBatchJobProcessor.cs
@@ -1,7 +1,7 @@
 using Valora.Domain.Entities;
 using Valora.Domain.Enums;
 
-namespace Valora.Application.Services.BatchJobs;
+namespace Valora.Application.Common.Interfaces;
 
 public interface IBatchJobProcessor
 {

--- a/backend/Valora.Application/Common/Interfaces/INotificationService.cs
+++ b/backend/Valora.Application/Common/Interfaces/INotificationService.cs
@@ -4,7 +4,7 @@ using System.Threading.Tasks;
 using Valora.Application.DTOs;
 using Valora.Domain.Enums;
 
-namespace Valora.Application.Services;
+namespace Valora.Application.Common.Interfaces;
 
 public interface INotificationService
 {

--- a/backend/Valora.Application/Services/BatchJobs/MapGenerationJobProcessor.cs
+++ b/backend/Valora.Application/Services/BatchJobs/MapGenerationJobProcessor.cs
@@ -1,4 +1,5 @@
 using Microsoft.Extensions.Logging;
+using Valora.Application.Common.Interfaces;
 using Valora.Domain.Entities;
 using Valora.Domain.Enums;
 


### PR DESCRIPTION
Moves application layer interfaces (`INotificationService`, `IBatchJobProcessor`) to their central and correct location (`backend/Valora.Application/Common/Interfaces/`) under the proper namespace (`Valora.Application.Common.Interfaces`) as instructed by the Valora Engineering Directives. Ensure `using` statements are correctly updated across implementations and dependency injection setup. Tests run smoothly without regressions.

---
*PR created automatically by Jules for task [7488841689450411529](https://jules.google.com/task/7488841689450411529) started by @YKDBontekoe*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Consolidated internal interface placement to simplify the code structure.
  * No user-facing or behavioral changes; low-risk maintenance update that improves long-term maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->