### PR TITLE
Refactor: Enforce Clean Architecture interface separation for Application services

### DIFF
--- a/backend/Valora.Api/Endpoints/NotificationEndpoints.cs
+++ b/backend/Valora.Api/Endpoints/NotificationEndpoints.cs
@@ -1,6 +1,6 @@
 using System.Security.Claims;
 using Microsoft.AspNetCore.Mvc;
-using Valora.Application.Services;
+using Valora.Application.Common.Interfaces;
 using Valora.Domain.Enums;
 
 namespace Valora.Api.Endpoints;

--- a/backend/Valora.Application/Common/Interfaces/IBatchJobProcessor.cs
+++ b/backend/Valora.Application/Common/Interfaces/IBatchJobProcessor.cs
@@ -1,7 +1,7 @@
 using Valora.Domain.Entities;
 using Valora.Domain.Enums;
 
-namespace Valora.Application.Services.BatchJobs;
+namespace Valora.Application.Common.Interfaces;
 
 public interface IBatchJobProcessor
 {

--- a/backend/Valora.Application/Common/Interfaces/INotificationService.cs
+++ b/backend/Valora.Application/Common/Interfaces/INotificationService.cs
@@ -4,7 +4,7 @@ using System.Threading.Tasks;
 using Valora.Application.DTOs;
 using Valora.Domain.Enums;
 
-namespace Valora.Application.Services;
+namespace Valora.Application.Common.Interfaces;
 
 public interface INotificationService
 {

--- a/backend/Valora.Application/Services/BatchJobs/CityIngestionJobProcessor.cs
+++ b/backend/Valora.Application/Services/BatchJobs/CityIngestionJobProcessor.cs
@@ -7,6 +7,8 @@ using Valora.Domain.Extensions;
 
 namespace Valora.Application.Services.BatchJobs;
 
+
+
 public class CityIngestionJobProcessor : IBatchJobProcessor
 {
     private readonly IBatchJobRepository _jobRepository;

--- a/backend/Valora.Application/Services/BatchJobs/CityIngestionJobProcessor.cs
+++ b/backend/Valora.Application/Services/BatchJobs/CityIngestionJobProcessor.cs
@@ -7,8 +7,6 @@ using Valora.Domain.Extensions;
 
 namespace Valora.Application.Services.BatchJobs;
 
-
-
 public class CityIngestionJobProcessor : IBatchJobProcessor
 {
     private readonly IBatchJobRepository _jobRepository;

--- a/backend/Valora.Application/Services/BatchJobs/MapGenerationJobProcessor.cs
+++ b/backend/Valora.Application/Services/BatchJobs/MapGenerationJobProcessor.cs
@@ -1,6 +1,7 @@
 using Microsoft.Extensions.Logging;
 using Valora.Domain.Entities;
 using Valora.Domain.Enums;
+using Valora.Application.Common.Interfaces;
 
 namespace Valora.Application.Services.BatchJobs;
 


### PR DESCRIPTION
This PR implements the Clean Architecture standard by moving `INotificationService` and `IBatchJobProcessor` from the application services layer directly to `Valora.Application.Common.Interfaces`. 

All dependent classes (endpoints, processors, test files) have had their namespace references and using statements updated to reflect this new interface location. This prevents the domain or application from incorrectly referencing infrastructure details, ensuring a cleaner architectural boundary. Tests have been run and confirm that everything is compiling and running properly.

---
*PR created automatically by Jules for task [9388025523351317032](https://jules.google.com/task/9388025523351317032) started by @YKDBontekoe*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal code structure reorganized to improve system architecture and maintainability with no impact to user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->