### PR TITLE
Add Confirmation Dialog to Quick Actions Retry Pipeline

### DIFF
--- a/apps/admin_page/src/components/dashboard/QuickActions.tsx
+++ b/apps/admin_page/src/components/dashboard/QuickActions.tsx
@@ -4,6 +4,7 @@ import { adminService } from '../../services/api';
 import { showToast } from '../../services/toast';
 import { useNavigate } from 'react-router-dom';
 import { motion } from 'framer-motion';
+import ConfirmationDialog from '../ConfirmationDialog';
 
 interface QuickActionsProps {
   onRefreshStats: () => void;
@@ -11,10 +12,16 @@ interface QuickActionsProps {
 
 const QuickActions = ({ onRefreshStats }: QuickActionsProps) => {
   const [retrying, setRetrying] = useState(false);
+  const [showRetryConfirmation, setShowRetryConfirmation] = useState(false);
   const navigate = useNavigate();
+
+  const handleRetryFailedJobsClick = () => {
+    setShowRetryConfirmation(true);
+  };
 
   const handleRetryFailedJobs = async () => {
     setRetrying(true);
+    setShowRetryConfirmation(false);
     try {
       const response = await adminService.getJobs(1, 100, 'Failed');
       const failedJobs = response.items;
@@ -59,7 +66,7 @@ const QuickActions = ({ onRefreshStats }: QuickActionsProps) => {
           title: 'Retry Pipeline',
           description: 'Re-queue all currently failed batch jobs.',
           icon: PlayCircle,
-          onClick: handleRetryFailedJobs,
+          onClick: handleRetryFailedJobsClick,
           isLoading: retrying,
           color: 'text-warning-600',
           bg: 'bg-warning-50',
@@ -121,6 +128,15 @@ const QuickActions = ({ onRefreshStats }: QuickActionsProps) => {
                 </motion.button>
             ))}
         </div>
+
+        <ConfirmationDialog
+            isOpen={showRetryConfirmation}
+            onClose={() => setShowRetryConfirmation(false)}
+            onConfirm={handleRetryFailedJobs}
+            title="Retry Failed Pipelines?"
+            message="Are you sure you want to re-queue all currently failed batch jobs? This will consume cluster resources."
+            confirmLabel="Retry Pipelines"
+        />
     </div>
   );
 };

--- a/apps/admin_page/src/pages/Dashboard.test.tsx
+++ b/apps/admin_page/src/pages/Dashboard.test.tsx
@@ -80,6 +80,12 @@ describe('Dashboard Page', () => {
     const retryButton = screen.getByText('Retry Pipeline');
     fireEvent.click(retryButton);
 
+    // Wait for confirmation dialog to appear
+    await waitFor(() => expect(screen.getByText('Retry Failed Pipelines?')).toBeInTheDocument());
+
+    const confirmButton = screen.getByText('Retry Pipelines');
+    fireEvent.click(confirmButton);
+
     await waitFor(() => {
       expect(adminService.getJobs).toHaveBeenCalled();
       expect(adminService.retryJob).toHaveBeenCalledTimes(2); // Should retry both failed jobs
@@ -109,6 +115,12 @@ describe('Dashboard Page', () => {
     const retryButton = screen.getByText('Retry Pipeline');
     fireEvent.click(retryButton);
 
+    // Wait for confirmation dialog to appear
+    await waitFor(() => expect(screen.getByText('Retry Failed Pipelines?')).toBeInTheDocument());
+
+    const confirmButton = screen.getByText('Retry Pipelines');
+    fireEvent.click(confirmButton);
+
     await waitFor(() => {
       expect(adminService.retryJob).toHaveBeenCalledTimes(2);
       // Only 1 succeeded
@@ -128,6 +140,12 @@ describe('Dashboard Page', () => {
     const retryButton = screen.getByText('Retry Pipeline');
     fireEvent.click(retryButton);
 
+    // Wait for confirmation dialog to appear
+    await waitFor(() => expect(screen.getByText('Retry Failed Pipelines?')).toBeInTheDocument());
+
+    const confirmButton = screen.getByText('Retry Pipelines');
+    fireEvent.click(confirmButton);
+
     await waitFor(() => {
       expect(adminService.retryJob).not.toHaveBeenCalled();
       expect(showToast).toHaveBeenCalledWith('No failed jobs found in the cluster.', 'info');
@@ -143,6 +161,12 @@ describe('Dashboard Page', () => {
 
     const retryButton = screen.getByText('Retry Pipeline');
     fireEvent.click(retryButton);
+
+    // Wait for confirmation dialog to appear
+    await waitFor(() => expect(screen.getByText('Retry Failed Pipelines?')).toBeInTheDocument());
+
+    const confirmButton = screen.getByText('Retry Pipelines');
+    fireEvent.click(confirmButton);
 
     await waitFor(() => {
       expect(showToast).toHaveBeenCalledWith('System failed to re-queue jobs.', 'error');

--- a/apps/admin_page/src/pages/Dashboard.test.tsx
+++ b/apps/admin_page/src/pages/Dashboard.test.tsx
@@ -173,6 +173,28 @@ describe('Dashboard Page', () => {
     });
   });
 
+  it('exercises the cancel/dismiss path of the confirmation dialog', async () => {
+    (adminService.getStats as Mock).mockResolvedValue({ totalUsers: 1, totalNotifications: 1 });
+
+    render(<MemoryRouter><Dashboard /></MemoryRouter>);
+    await waitFor(() => expect(screen.getByText('System Infrastructure')).toBeInTheDocument());
+
+    const retryButton = screen.getByText('Retry Pipeline');
+    fireEvent.click(retryButton);
+
+    // Wait for confirmation dialog to appear
+    await waitFor(() => expect(screen.getByText('Retry Failed Pipelines?')).toBeInTheDocument());
+
+    const cancelButton = screen.getByRole('button', { name: 'Cancel' });
+    fireEvent.click(cancelButton);
+
+    await waitFor(() => {
+      expect(screen.queryByText('Retry Failed Pipelines?')).not.toBeInTheDocument();
+      expect(adminService.getJobs).not.toHaveBeenCalled();
+      expect(adminService.retryJob).not.toHaveBeenCalled();
+    });
+  });
+
   it('navigates to users page on Manage Users click', async () => {
      (adminService.getStats as Mock).mockResolvedValue({ totalUsers: 1, totalNotifications: 1 });
      render(<MemoryRouter><Dashboard /></MemoryRouter>);


### PR DESCRIPTION
Adds a confirmation dialog to the "Retry Pipeline" quick action on the dashboard to prevent accidental re-queuing of failed batch jobs, which can consume significant cluster resources.

---
*PR created automatically by Jules for task [15136563189196260091](https://jules.google.com/task/15136563189196260091) started by @YKDBontekoe*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds a confirmation dialog for retrying failed pipeline jobs, requiring explicit user confirmation and providing feedback during and after the retry process.

* **Tests**
  * Updated automated tests to cover the confirmation flow, including confirm and cancel paths, and to validate success/failure feedback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->