### PR TITLE
Add concurrency integration test for batch job claiming

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -113,3 +113,6 @@ test_output.txt
 *.patch
 *.orig
 *.rej
+
+# Test Results
+**/TestResults/

--- a/backend/Valora.IntegrationTests/BatchJobRepositoryIntegrationTests.cs
+++ b/backend/Valora.IntegrationTests/BatchJobRepositoryIntegrationTests.cs
@@ -1,0 +1,81 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Valora.Application.Common.Interfaces;
+using Valora.Domain.Entities;
+using Valora.Infrastructure.Persistence;
+using Xunit;
+
+namespace Valora.IntegrationTests;
+
+public class BatchJobRepositoryIntegrationTests : BaseIntegrationTest
+{
+    public BatchJobRepositoryIntegrationTests(TestDatabaseFixture fixture) : base(fixture)
+    {
+    }
+
+    [Fact]
+    public async Task GetNextPendingJobAsync_ShouldAtomicallyClaimJob()
+    {
+        // Arrange
+        // Create a single pending job
+        var pendingJob = new BatchJob
+        {
+            Id = Guid.NewGuid(),
+            Type = BatchJobType.CityIngestion,
+            Status = BatchJobStatus.Pending,
+            Target = "ConcurrentTestCity",
+            CreatedAt = DateTime.UtcNow
+        };
+
+        DbContext.BatchJobs.Add(pendingJob);
+        await DbContext.SaveChangesAsync();
+
+        // Ensure ChangeTracker is cleared so we query real DB state
+        DbContext.ChangeTracker.Clear();
+
+        int concurrentWorkers = 5;
+        var tasks = new List<Task<BatchJob?>>();
+
+        // Act
+        // Attempt to claim the job simultaneously from multiple scopes
+        for (int i = 0; i < concurrentWorkers; i++)
+        {
+            var scope = Factory.Services.CreateScope();
+            var repository = scope.ServiceProvider.GetRequiredService<IBatchJobRepository>();
+            tasks.Add(repository.GetNextPendingJobAsync());
+        }
+
+        var results = await Task.WhenAll(tasks);
+
+        // Assert
+        var successfulClaims = results.Where(r => r != null).ToList();
+
+        // Exactly one worker should have successfully claimed the job
+        Assert.Single(successfulClaims);
+
+        var claimedJob = successfulClaims.First();
+        Assert.NotNull(claimedJob);
+        Assert.Equal(pendingJob.Id, claimedJob.Id);
+        Assert.Equal(BatchJobStatus.Processing, claimedJob.Status);
+        Assert.NotNull(claimedJob.StartedAt);
+
+        // Verify database state using a fresh context
+        using var verifyScope = Factory.Services.CreateScope();
+        var verifyDbContext = verifyScope.ServiceProvider.GetRequiredService<ValoraDbContext>();
+
+        var dbJob = await verifyDbContext.BatchJobs.FirstOrDefaultAsync(j => j.Id == pendingJob.Id);
+
+        Assert.NotNull(dbJob);
+        Assert.Equal(BatchJobStatus.Processing, dbJob.Status);
+        Assert.NotNull(dbJob.StartedAt);
+
+        // Ensure only one job exists in the table to be safe
+        var totalJobsCount = await verifyDbContext.BatchJobs.CountAsync();
+        Assert.Equal(1, totalJobsCount);
+    }
+}

--- a/backend/Valora.IntegrationTests/BatchJobRepositoryIntegrationTests.cs
+++ b/backend/Valora.IntegrationTests/BatchJobRepositoryIntegrationTests.cs
@@ -15,28 +15,30 @@ namespace Valora.IntegrationTests;
 
 public class BatchJobRepositoryIntegrationTests : IDisposable
 {
-    private readonly SqliteConnection _connection;
-    private readonly DbContextOptions<ValoraDbContext> _options;
+    private readonly SqliteConnection _anchorConnection;
     private readonly ServiceProvider _serviceProvider;
 
     public BatchJobRepositoryIntegrationTests()
     {
-        // Use a persistent SQLite in-memory database specifically for testing relational features
-        // like ExecuteUpdateAsync which are not supported by the InMemory provider.
-        _connection = new SqliteConnection("DataSource=:memory:");
-        _connection.Open();
+        // Use a shared-cache in-memory connection string to allow multiple thread-safe connections
+        // to the same in-memory database.
+        var connectionString = "Data Source=BatchJobTestDb;Mode=Memory;Cache=Shared";
 
-        _options = new DbContextOptionsBuilder<ValoraDbContext>()
-            .UseSqlite(_connection)
-            .Options;
+        // Open a single anchor SqliteConnection and keep it open to preserve the in-memory DB
+        // throughout the lifetime of the test.
+        _anchorConnection = new SqliteConnection(connectionString);
+        _anchorConnection.Open();
 
         // Ensure the schema is created in the SQLite database
-        using var context = new ValoraDbContext(_options);
+        var options = new DbContextOptionsBuilder<ValoraDbContext>()
+            .UseSqlite(connectionString)
+            .Options;
+        using var context = new ValoraDbContext(options);
         context.Database.EnsureCreated();
 
-        // Setup DI similar to what WebAppFactory does, but wired to SQLite
+        // Setup DI. Use the connection string so each scope creates its own thread-safe connection.
         var services = new ServiceCollection();
-        services.AddDbContext<ValoraDbContext>(opts => opts.UseSqlite(_connection));
+        services.AddDbContext<ValoraDbContext>(opts => opts.UseSqlite(connectionString));
         services.AddScoped<IBatchJobRepository, Valora.Infrastructure.Persistence.Repositories.BatchJobRepository>();
 
         _serviceProvider = services.BuildServiceProvider();
@@ -46,7 +48,6 @@ public class BatchJobRepositoryIntegrationTests : IDisposable
     public async Task GetNextPendingJobAsync_ShouldAtomicallyClaimJob_WithRelationalDb()
     {
         // Arrange
-        // Create a single pending job using a dedicated scope
         var pendingJob = new BatchJob
         {
             Id = Guid.NewGuid(),
@@ -66,23 +67,17 @@ public class BatchJobRepositoryIntegrationTests : IDisposable
         int concurrentWorkers = 5;
         var tasks = new List<Task<BatchJob?>>();
 
-        // Use a Barrier to synchronize the start of all worker tasks
         var startGate = new Barrier(concurrentWorkers);
 
         // Act
-        // Attempt to claim the job simultaneously from multiple scopes
         for (int i = 0; i < concurrentWorkers; i++)
         {
             tasks.Add(Task.Run(async () =>
             {
-                // Wait for all workers to be ready to call the repository
                 startGate.SignalAndWait();
 
-                // Delay execution randomly slightly to increase chance of concurrent ExecuteUpdateAsync clashes
-                // We use Thread.Sleep to not yield the thread before creating the scope
                 Thread.Sleep(Random.Shared.Next(1, 10));
 
-                // Create the scope inside the worker delegate
                 using var scope = _serviceProvider.CreateScope();
                 var repository = scope.ServiceProvider.GetRequiredService<IBatchJobRepository>();
 
@@ -90,16 +85,25 @@ public class BatchJobRepositoryIntegrationTests : IDisposable
                 {
                     return await repository.GetNextPendingJobAsync();
                 }
-                catch (DbUpdateException)
+                catch (DbUpdateException ex) when (ex.InnerException is SqliteException sqliteEx)
                 {
-                    // SQLite throws DbUpdateException if the database is locked during a concurrent ExecuteUpdateAsync.
-                    // A real relational DB like Postgres would lock the row and execute sequentially, returning 0 rows affected.
-                    // In this test, a DbUpdateException indicates another worker claimed it and locked the DB, which is a valid negative result.
-                    return null;
+                    // DbUpdateException wraps SqliteException from SaveChanges/SaveChangesAsync.
+                    // If SQLite is busy or locked (5 or 6), it means another worker successfully claimed
+                    // and locked the database. This is a valid negative result (no claim).
+                    if (sqliteEx.SqliteErrorCode is 5 or 6) // SQLITE_BUSY or SQLITE_LOCKED
+                    {
+                        return null;
+                    }
+                    throw;
                 }
-                catch (SqliteException)
+                catch (SqliteException sqliteEx)
                 {
-                    return null;
+                    // Catch direct SqliteExceptions in case ExecuteUpdateAsync throws it directly
+                    if (sqliteEx.SqliteErrorCode is 5 or 6) // SQLITE_BUSY or SQLITE_LOCKED
+                    {
+                        return null;
+                    }
+                    throw;
                 }
             }));
         }
@@ -109,7 +113,6 @@ public class BatchJobRepositoryIntegrationTests : IDisposable
         // Assert
         var successfulClaims = results.Where(r => r != null).ToList();
 
-        // Ensure only a single worker claimed the job.
         Assert.Single(successfulClaims);
 
         var claimedJob = successfulClaims.First();
@@ -129,7 +132,6 @@ public class BatchJobRepositoryIntegrationTests : IDisposable
             Assert.Equal(BatchJobStatus.Processing, dbJob.Status);
             Assert.NotNull(dbJob.StartedAt);
 
-            // Ensure only one job exists in the table to be safe
             var totalJobsCount = await verifyDbContext.BatchJobs.CountAsync();
             Assert.Equal(1, totalJobsCount);
         }
@@ -138,6 +140,6 @@ public class BatchJobRepositoryIntegrationTests : IDisposable
     public void Dispose()
     {
         _serviceProvider?.Dispose();
-        _connection?.Dispose();
+        _anchorConnection?.Dispose();
     }
 }

--- a/backend/Valora.IntegrationTests/BatchJobRepositoryIntegrationTests.cs
+++ b/backend/Valora.IntegrationTests/BatchJobRepositoryIntegrationTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Valora.Application.Common.Interfaces;
@@ -12,17 +13,40 @@ using Xunit;
 
 namespace Valora.IntegrationTests;
 
-public class BatchJobRepositoryIntegrationTests : BaseIntegrationTest
+public class BatchJobRepositoryIntegrationTests : IDisposable
 {
-    public BatchJobRepositoryIntegrationTests(TestDatabaseFixture fixture) : base(fixture)
+    private readonly SqliteConnection _connection;
+    private readonly DbContextOptions<ValoraDbContext> _options;
+    private readonly ServiceProvider _serviceProvider;
+
+    public BatchJobRepositoryIntegrationTests()
     {
+        // Use a persistent SQLite in-memory database specifically for testing relational features
+        // like ExecuteUpdateAsync which are not supported by the InMemory provider.
+        _connection = new SqliteConnection("DataSource=:memory:");
+        _connection.Open();
+
+        _options = new DbContextOptionsBuilder<ValoraDbContext>()
+            .UseSqlite(_connection)
+            .Options;
+
+        // Ensure the schema is created in the SQLite database
+        using var context = new ValoraDbContext(_options);
+        context.Database.EnsureCreated();
+
+        // Setup DI similar to what WebAppFactory does, but wired to SQLite
+        var services = new ServiceCollection();
+        services.AddDbContext<ValoraDbContext>(opts => opts.UseSqlite(_connection));
+        services.AddScoped<IBatchJobRepository, Valora.Infrastructure.Persistence.Repositories.BatchJobRepository>();
+
+        _serviceProvider = services.BuildServiceProvider();
     }
 
     [Fact]
-    public async Task GetNextPendingJobAsync_ShouldAtomicallyClaimJob()
+    public async Task GetNextPendingJobAsync_ShouldAtomicallyClaimJob_WithRelationalDb()
     {
         // Arrange
-        // Create a single pending job
+        // Create a single pending job using a dedicated scope
         var pendingJob = new BatchJob
         {
             Id = Guid.NewGuid(),
@@ -32,22 +56,52 @@ public class BatchJobRepositoryIntegrationTests : BaseIntegrationTest
             CreatedAt = DateTime.UtcNow
         };
 
-        DbContext.BatchJobs.Add(pendingJob);
-        await DbContext.SaveChangesAsync();
-
-        // Ensure ChangeTracker is cleared so we query real DB state
-        DbContext.ChangeTracker.Clear();
+        using (var arrangeScope = _serviceProvider.CreateScope())
+        {
+            var dbContext = arrangeScope.ServiceProvider.GetRequiredService<ValoraDbContext>();
+            dbContext.BatchJobs.Add(pendingJob);
+            await dbContext.SaveChangesAsync();
+        }
 
         int concurrentWorkers = 5;
         var tasks = new List<Task<BatchJob?>>();
+
+        // Use a Barrier to synchronize the start of all worker tasks
+        var startGate = new Barrier(concurrentWorkers);
 
         // Act
         // Attempt to claim the job simultaneously from multiple scopes
         for (int i = 0; i < concurrentWorkers; i++)
         {
-            var scope = Factory.Services.CreateScope();
-            var repository = scope.ServiceProvider.GetRequiredService<IBatchJobRepository>();
-            tasks.Add(repository.GetNextPendingJobAsync());
+            tasks.Add(Task.Run(async () =>
+            {
+                // Wait for all workers to be ready to call the repository
+                startGate.SignalAndWait();
+
+                // Delay execution randomly slightly to increase chance of concurrent ExecuteUpdateAsync clashes
+                // We use Thread.Sleep to not yield the thread before creating the scope
+                Thread.Sleep(Random.Shared.Next(1, 10));
+
+                // Create the scope inside the worker delegate
+                using var scope = _serviceProvider.CreateScope();
+                var repository = scope.ServiceProvider.GetRequiredService<IBatchJobRepository>();
+
+                try
+                {
+                    return await repository.GetNextPendingJobAsync();
+                }
+                catch (DbUpdateException)
+                {
+                    // SQLite throws DbUpdateException if the database is locked during a concurrent ExecuteUpdateAsync.
+                    // A real relational DB like Postgres would lock the row and execute sequentially, returning 0 rows affected.
+                    // In this test, a DbUpdateException indicates another worker claimed it and locked the DB, which is a valid negative result.
+                    return null;
+                }
+                catch (SqliteException)
+                {
+                    return null;
+                }
+            }));
         }
 
         var results = await Task.WhenAll(tasks);
@@ -55,7 +109,7 @@ public class BatchJobRepositoryIntegrationTests : BaseIntegrationTest
         // Assert
         var successfulClaims = results.Where(r => r != null).ToList();
 
-        // Exactly one worker should have successfully claimed the job
+        // Ensure only a single worker claimed the job.
         Assert.Single(successfulClaims);
 
         var claimedJob = successfulClaims.First();
@@ -65,17 +119,25 @@ public class BatchJobRepositoryIntegrationTests : BaseIntegrationTest
         Assert.NotNull(claimedJob.StartedAt);
 
         // Verify database state using a fresh context
-        using var verifyScope = Factory.Services.CreateScope();
-        var verifyDbContext = verifyScope.ServiceProvider.GetRequiredService<ValoraDbContext>();
+        using (var verifyScope = _serviceProvider.CreateScope())
+        {
+            var verifyDbContext = verifyScope.ServiceProvider.GetRequiredService<ValoraDbContext>();
 
-        var dbJob = await verifyDbContext.BatchJobs.FirstOrDefaultAsync(j => j.Id == pendingJob.Id);
+            var dbJob = await verifyDbContext.BatchJobs.FirstOrDefaultAsync(j => j.Id == pendingJob.Id);
 
-        Assert.NotNull(dbJob);
-        Assert.Equal(BatchJobStatus.Processing, dbJob.Status);
-        Assert.NotNull(dbJob.StartedAt);
+            Assert.NotNull(dbJob);
+            Assert.Equal(BatchJobStatus.Processing, dbJob.Status);
+            Assert.NotNull(dbJob.StartedAt);
 
-        // Ensure only one job exists in the table to be safe
-        var totalJobsCount = await verifyDbContext.BatchJobs.CountAsync();
-        Assert.Equal(1, totalJobsCount);
+            // Ensure only one job exists in the table to be safe
+            var totalJobsCount = await verifyDbContext.BatchJobs.CountAsync();
+            Assert.Equal(1, totalJobsCount);
+        }
+    }
+
+    public void Dispose()
+    {
+        _serviceProvider?.Dispose();
+        _connection?.Dispose();
     }
 }

--- a/backend/Valora.IntegrationTests/Valora.IntegrationTests.csproj
+++ b/backend/Valora.IntegrationTests/Valora.IntegrationTests.csproj
@@ -10,6 +10,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.3" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.3" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="Shouldly" Version="4.2.1" />


### PR DESCRIPTION
Added integration test to verify the atomic claiming of batch jobs and ignored test outputs.

---
*PR created automatically by Jules for task [6577979556156012064](https://jules.google.com/task/6577979556156012064) started by @YKDBontekoe*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added an integration test that verifies atomic claiming of a pending batch job under concurrent workers and confirms only one worker claims and persists the job state.

* **Chores**
  * Updated repository settings to ignore TestResults directories.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->