### PR TITLE
Add integration test for BatchJobRepository.GetNextPendingJobAsync

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -113,3 +113,4 @@ test_output.txt
 *.patch
 *.orig
 *.rej
+TestResults/

--- a/backend/Valora.IntegrationTests/BatchJobRepositoryIntegrationTests.cs
+++ b/backend/Valora.IntegrationTests/BatchJobRepositoryIntegrationTests.cs
@@ -1,0 +1,97 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Valora.Application.Common.Interfaces;
+using Valora.Domain.Entities;
+using Valora.Infrastructure.Persistence;
+using Xunit;
+
+namespace Valora.IntegrationTests;
+
+[Collection("TestcontainersDatabase")]
+public class BatchJobRepositoryIntegrationTests : BaseTestcontainersIntegrationTest
+{
+    public BatchJobRepositoryIntegrationTests(TestcontainersDatabaseFixture fixture) : base(fixture)
+    {
+    }
+
+    [Fact]
+    public async Task GetNextPendingJobAsync_ShouldReturnOldestPendingJob_AndSetStatusToProcessing()
+    {
+        // Arrange
+        using var scope = Factory.Services.CreateScope();
+        var repository = scope.ServiceProvider.GetRequiredService<IBatchJobRepository>();
+        var context = scope.ServiceProvider.GetRequiredService<ValoraDbContext>();
+
+        var job1 = new BatchJob { Type = BatchJobType.CityIngestion, Target = "Job1", Status = BatchJobStatus.Pending, CreatedAt = DateTime.UtcNow.AddMinutes(-10) };
+        var job2 = new BatchJob { Type = BatchJobType.CityIngestion, Target = "Job2", Status = BatchJobStatus.Pending, CreatedAt = DateTime.UtcNow.AddMinutes(-5) };
+        var job3 = new BatchJob { Type = BatchJobType.CityIngestion, Target = "Job3", Status = BatchJobStatus.Processing, CreatedAt = DateTime.UtcNow.AddMinutes(-15) };
+
+        context.BatchJobs.AddRange(job1, job2, job3);
+        await context.SaveChangesAsync();
+        context.ChangeTracker.Clear();
+
+        // Act
+        var result = await repository.GetNextPendingJobAsync();
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal("Job1", result.Target);
+        Assert.Equal(BatchJobStatus.Processing, result.Status);
+        Assert.NotNull(result.StartedAt);
+
+        // Verify side-effect in DB
+        context.ChangeTracker.Clear();
+        var updatedJobInDb = await context.BatchJobs.FindAsync(job1.Id);
+        Assert.NotNull(updatedJobInDb);
+        Assert.Equal(BatchJobStatus.Processing, updatedJobInDb.Status);
+        Assert.NotNull(updatedJobInDb.StartedAt);
+    }
+
+    [Fact]
+    public async Task GetNextPendingJobAsync_Concurrency_ShouldOnlyClaimOnce()
+    {
+        // Arrange
+        using var setupScope = Factory.Services.CreateScope();
+        var context = setupScope.ServiceProvider.GetRequiredService<ValoraDbContext>();
+
+        var job = new BatchJob { Type = BatchJobType.CityIngestion, Target = "ConcurrentJob", Status = BatchJobStatus.Pending, CreatedAt = DateTime.UtcNow };
+        context.BatchJobs.Add(job);
+        await context.SaveChangesAsync();
+        context.ChangeTracker.Clear();
+
+        int concurrentWorkers = 5;
+        var tasks = new Task<BatchJob?>[concurrentWorkers];
+        var scopes = new IServiceScope[concurrentWorkers];
+
+        // Act
+        for (int i = 0; i < concurrentWorkers; i++)
+        {
+            scopes[i] = Factory.Services.CreateScope();
+            var repo = scopes[i].ServiceProvider.GetRequiredService<IBatchJobRepository>();
+            tasks[i] = repo.GetNextPendingJobAsync();
+        }
+
+        var results = await Task.WhenAll(tasks);
+
+        // Cleanup scopes
+        foreach (var scope in scopes)
+        {
+            scope.Dispose();
+        }
+
+        // Assert
+        // Only one worker should have successfully claimed the job
+        var successfulClaims = results.Where(r => r != null).ToList();
+        Assert.Single(successfulClaims);
+        Assert.Equal("ConcurrentJob", successfulClaims[0]!.Target);
+
+        // Verify side-effect in DB
+        using var assertScope = Factory.Services.CreateScope();
+        var assertContext = assertScope.ServiceProvider.GetRequiredService<ValoraDbContext>();
+        var updatedJobInDb = await assertContext.BatchJobs.FindAsync(job.Id);
+
+        Assert.NotNull(updatedJobInDb);
+        Assert.Equal(BatchJobStatus.Processing, updatedJobInDb.Status);
+        Assert.NotNull(updatedJobInDb.StartedAt);
+    }
+}

--- a/backend/Valora.UnitTests/Infrastructure/Persistence/Repositories/BatchJobRepositoryTests.cs
+++ b/backend/Valora.UnitTests/Infrastructure/Persistence/Repositories/BatchJobRepositoryTests.cs
@@ -45,29 +45,6 @@ public class BatchJobRepositoryTests
         Assert.Equal("Amsterdam", result.Target);
     }
 
-    // Skipped: ExecuteUpdateAsync is not supported by EF Core InMemory provider.
-    // Ideally this should be an integration test against a real DB (e.g. Testcontainers).
-    // For unit testing logic, we would need to abstract the DbContext or use a different mocking strategy,
-    // but verifying EF Core's ExecuteUpdateAsync behavior against InMemory is impossible.
-    [Fact(Skip = "ExecuteUpdateAsync not supported by InMemory provider")]
-    public async Task GetNextPendingJobAsync_ShouldReturnOldestPendingJob()
-    {
-        using var context = new ValoraDbContext(CreateOptions());
-        // Setup data
-        var job1 = new BatchJob { Type = BatchJobType.CityIngestion, Target = "Job1", Status = BatchJobStatus.Pending, CreatedAt = DateTime.UtcNow.AddMinutes(-10) };
-        var job2 = new BatchJob { Type = BatchJobType.CityIngestion, Target = "Job2", Status = BatchJobStatus.Pending, CreatedAt = DateTime.UtcNow.AddMinutes(-5) };
-        var job3 = new BatchJob { Type = BatchJobType.CityIngestion, Target = "Job3", Status = BatchJobStatus.Processing };
-
-        context.BatchJobs.AddRange(job1, job2, job3);
-        await context.SaveChangesAsync();
-
-        var repository = new BatchJobRepository(context);
-        var result = await repository.GetNextPendingJobAsync();
-
-        Assert.NotNull(result);
-        Assert.Equal("Job1", result.Target);
-    }
-
     [Fact]
     public async Task GetRecentJobsAsync_ShouldReturnLatestJobs()
     {


### PR DESCRIPTION
Added integration tests to properly cover critical path logic for atomic queue claiming in `BatchJobRepository`.

---
*PR created automatically by Jules for task [2359138263206721136](https://jules.google.com/task/2359138263206721136) started by @YKDBontekoe*