### PR TITLE
refactor(ui): apply ValoraSpacing design tokens and improve shadows

### DIFF
--- a/apps/flutter_app/lib/screens/context_report/layouts/search_layout.dart
+++ b/apps/flutter_app/lib/screens/context_report/layouts/search_layout.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_animate/flutter_animate.dart';
 import '../../../widgets/valora_widgets.dart';
 import '../../../core/theme/valora_typography.dart';
+import '../../../core/theme/valora_spacing.dart';
 import '../../../services/pdok_service.dart';
 import '../../../providers/context_report_provider.dart';
 import '../widgets/search_field.dart';
@@ -30,14 +31,14 @@ class SearchLayout extends StatelessWidget {
         // Minimal top spacing for status bar
         SliverToBoxAdapter(
           child: SizedBox(
-            height: MediaQuery.of(context).padding.top + 16,
+            height: MediaQuery.of(context).padding.top + ValoraSpacing.lg,
           ),
         ),
 
         // Hero section
         SliverToBoxAdapter(
           child: Padding(
-            padding: const EdgeInsets.symmetric(horizontal: 20),
+            padding: const EdgeInsets.symmetric(horizontal: ValoraSpacing.lg),
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
@@ -45,7 +46,7 @@ class SearchLayout extends StatelessWidget {
                 Row(
                   children: [
                     Container(
-                      padding: const EdgeInsets.all(12),
+                      padding: const EdgeInsets.all(ValoraSpacing.sm),
                       decoration: BoxDecoration(
                         gradient: LinearGradient(
                           colors: [
@@ -55,7 +56,7 @@ class SearchLayout extends StatelessWidget {
                           begin: Alignment.bottomLeft,
                           end: Alignment.topRight,
                         ),
-                        borderRadius: BorderRadius.circular(16),
+                        borderRadius: BorderRadius.circular(ValoraSpacing.radiusLg),
                         boxShadow: [
                           BoxShadow(
                             color: Theme.of(context).colorScheme.primary.withValues(alpha: 0.25),
@@ -77,7 +78,7 @@ class SearchLayout extends StatelessWidget {
                        duration: 2000.ms,
                        curve: Curves.easeInOutSine,
                      ),
-                    const SizedBox(width: 14),
+                    const SizedBox(width: ValoraSpacing.md),
                     Column(
                       crossAxisAlignment: CrossAxisAlignment.start,
                       children: [
@@ -98,7 +99,7 @@ class SearchLayout extends StatelessWidget {
                     ),
                   ],
                 ).animate().fadeIn(duration: 400.ms).slideX(begin: -0.05),
-                const SizedBox(height: 32),
+                const SizedBox(height: ValoraSpacing.xl),
 
                 // Search field
                 SearchField(
@@ -107,7 +108,7 @@ class SearchLayout extends StatelessWidget {
                   pdokService: pdokService,
                 ).animate().fadeIn(duration: 400.ms, delay: 100.ms).slideY(begin: 0.1),
 
-                const SizedBox(height: 16),
+                const SizedBox(height: ValoraSpacing.md),
 
                 // Radius selector
                 const RadiusSelector()
@@ -115,7 +116,7 @@ class SearchLayout extends StatelessWidget {
                     .fadeIn(duration: 400.ms, delay: 200.ms)
                     .slideY(begin: 0.1),
 
-                const SizedBox(height: 20),
+                const SizedBox(height: ValoraSpacing.md),
 
                 // Generate button
                 GenerateButton(
@@ -125,7 +126,7 @@ class SearchLayout extends StatelessWidget {
 
                 // Error state
                 if (provider.error != null) ...[
-                  const SizedBox(height: 24),
+                  const SizedBox(height: ValoraSpacing.lg),
                   ValoraEmptyState(
                     icon: Icons.error_outline_rounded,
                     title: 'Analysis Failed',
@@ -142,7 +143,7 @@ class SearchLayout extends StatelessWidget {
         // Quick actions
         SliverToBoxAdapter(
           child: Padding(
-            padding: const EdgeInsets.fromLTRB(20, 32, 20, 0),
+            padding: const EdgeInsets.fromLTRB(ValoraSpacing.lg, ValoraSpacing.xl, ValoraSpacing.lg, 0),
             child: QuickActions(pdokService: pdokService, provider: provider, controller: inputController)
                 .animate()
                 .fadeIn(duration: 400.ms, delay: 350.ms),
@@ -152,7 +153,7 @@ class SearchLayout extends StatelessWidget {
         // Saved Searches section
         SliverToBoxAdapter(
           child: Padding(
-            padding: const EdgeInsets.only(top: 32),
+            padding: const EdgeInsets.only(top: ValoraSpacing.xl),
             child: SavedSearchesSection(
               controller: inputController,
               provider: provider,
@@ -170,7 +171,7 @@ class SearchLayout extends StatelessWidget {
 
         // Bottom padding for nav bar
         const SliverToBoxAdapter(
-          child: SizedBox(height: 120),
+          child: SizedBox(height: 120.0),
         ),
       ],
     );

--- a/apps/flutter_app/lib/screens/context_report/widgets/history_section.dart
+++ b/apps/flutter_app/lib/screens/context_report/widgets/history_section.dart
@@ -4,6 +4,7 @@ import 'package:intl/intl.dart';
 import '../../../widgets/valora_widgets.dart';
 import 'package:flutter_animate/flutter_animate.dart';
 import '../../../core/theme/valora_typography.dart';
+import '../../../core/theme/valora_spacing.dart';
 import '../../../providers/context_report_provider.dart';
 
 class HistorySection extends StatelessWidget {
@@ -25,7 +26,7 @@ class HistorySection extends StatelessWidget {
       builder: (context, history, _) {
         if (history.isEmpty) return const SizedBox.shrink();
         return Padding(
-          padding: const EdgeInsets.fromLTRB(20, 32, 20, 0),
+          padding: const EdgeInsets.fromLTRB(ValoraSpacing.lg, ValoraSpacing.xl, ValoraSpacing.lg, 0),
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
@@ -43,25 +44,25 @@ class HistorySection extends StatelessWidget {
                   ),
                 ],
               ),
-              const SizedBox(height: 12),
+              const SizedBox(height: ValoraSpacing.sm),
               ...history.take(5).toList().asMap().entries.map((entry) {
                 final index = entry.key;
                 final item = entry.value;
                 return Padding(
-                  padding: const EdgeInsets.only(bottom: 8),
+                  padding: const EdgeInsets.only(bottom: ValoraSpacing.sm),
                   child: ValoraCard(
+                    elevation: ValoraSpacing.elevationSm,
                     onTap: provider.isLoading
                         ? null
                         : () {
                             controller.text = item.query;
                             provider.generate(item.query);
                           },
-                    padding: const EdgeInsets.symmetric(
-                        horizontal: 16, vertical: 14),
+                    padding: const EdgeInsets.all(ValoraSpacing.md),
                     child: Row(
                       children: [
                         Container(
-                          padding: const EdgeInsets.all(8),
+                          padding: const EdgeInsets.all(ValoraSpacing.sm),
                           decoration: BoxDecoration(
                             color: theme.colorScheme.primary
                                 .withValues(alpha: 0.08),
@@ -69,11 +70,11 @@ class HistorySection extends StatelessWidget {
                           ),
                           child: Icon(
                             Icons.history_rounded,
-                            size: 16,
+                            size: ValoraSpacing.iconSizeSm,
                             color: theme.colorScheme.primary,
                           ),
                         ),
-                        const SizedBox(width: 14),
+                        const SizedBox(width: ValoraSpacing.md),
                         Expanded(
                           child: Column(
                             crossAxisAlignment: CrossAxisAlignment.start,
@@ -86,7 +87,7 @@ class HistorySection extends StatelessWidget {
                                   fontWeight: FontWeight.w600,
                                 ),
                               ),
-                              const SizedBox(height: 2),
+                              const SizedBox(height: ValoraSpacing.xs),
                               Text(
                                 _formatDate(item.timestamp),
                                 style: ValoraTypography.labelSmall.copyWith(
@@ -107,7 +108,7 @@ class HistorySection extends StatelessWidget {
                                     item.query, provider.radiusMeters)
                                 ? Icons.playlist_add_check_rounded
                                 : Icons.playlist_add_rounded,
-                            size: 20,
+                            size: ValoraSpacing.iconSizeMd,
                             color: provider.isComparing(
                                     item.query, provider.radiusMeters)
                                 ? theme.colorScheme.primary
@@ -125,7 +126,7 @@ class HistorySection extends StatelessWidget {
                                   backgroundColor: theme.colorScheme.error,
                                   behavior: SnackBarBehavior.floating,
                                   shape: RoundedRectangleBorder(
-                                      borderRadius: BorderRadius.circular(12)),
+                                      borderRadius: BorderRadius.circular(ValoraSpacing.radiusMd)),
                                 ),
                               );
                             }
@@ -133,7 +134,7 @@ class HistorySection extends StatelessWidget {
                         ),
                         Icon(
                           Icons.chevron_right_rounded,
-                          size: 20,
+                          size: ValoraSpacing.iconSizeMd,
                           color: theme.colorScheme.onSurfaceVariant,
                         ),
                       ],

--- a/apps/flutter_app/lib/screens/context_report/widgets/quick_actions.dart
+++ b/apps/flutter_app/lib/screens/context_report/widgets/quick_actions.dart
@@ -23,6 +23,9 @@ class QuickActions extends StatelessWidget {
   final TextEditingController controller;
   final LocationService _locationService;
 
+  static final _snackBarShape =
+      RoundedRectangleBorder(borderRadius: BorderRadius.circular(ValoraSpacing.radiusMd));
+
   Future<void> _pickLocation(BuildContext context) async {
     final LatLng? result = await Navigator.push<LatLng>(
       context,
@@ -36,8 +39,7 @@ class QuickActions extends StatelessWidget {
           content: const Text('Resolving address…'),
           duration: const Duration(seconds: 1),
           behavior: SnackBarBehavior.floating,
-          shape:
-              RoundedRectangleBorder(borderRadius: BorderRadius.circular(ValoraSpacing.radiusMd)),
+          shape: _snackBarShape,
         ),
       );
 
@@ -58,8 +60,7 @@ class QuickActions extends StatelessWidget {
                   'Could not resolve an address. Try searching by text.'),
               backgroundColor: Theme.of(context).colorScheme.error,
               behavior: SnackBarBehavior.floating,
-              shape: RoundedRectangleBorder(
-                  borderRadius: BorderRadius.circular(ValoraSpacing.radiusMd)),
+              shape: _snackBarShape,
             ),
           );
         }
@@ -72,7 +73,7 @@ class QuickActions extends StatelessWidget {
             content: const Text('Could not determine location.'),
             backgroundColor: Theme.of(context).colorScheme.error,
             behavior: SnackBarBehavior.floating,
-            shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(ValoraSpacing.radiusMd)),
+            shape: _snackBarShape,
           ),
         );
       }
@@ -85,7 +86,7 @@ class QuickActions extends StatelessWidget {
         content: const Text('Getting location…'),
         duration: const Duration(seconds: 1),
         behavior: SnackBarBehavior.floating,
-        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(ValoraSpacing.radiusMd)),
+        shape: _snackBarShape,
       ),
     );
 
@@ -99,7 +100,7 @@ class QuickActions extends StatelessWidget {
           content: const Text('Resolving address…'),
           duration: const Duration(seconds: 1),
           behavior: SnackBarBehavior.floating,
-          shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(ValoraSpacing.radiusMd)),
+          shape: _snackBarShape,
         ),
       );
 
@@ -131,7 +132,7 @@ class QuickActions extends StatelessWidget {
               content: const Text('Could not resolve an address for your location.'),
               backgroundColor: Theme.of(context).colorScheme.error,
               behavior: SnackBarBehavior.floating,
-              shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(ValoraSpacing.radiusMd)),
+              shape: _snackBarShape,
             ),
           );
         }
@@ -144,7 +145,7 @@ class QuickActions extends StatelessWidget {
             content: const Text('Could not determine location.'),
             backgroundColor: Theme.of(context).colorScheme.error,
             behavior: SnackBarBehavior.floating,
-            shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(ValoraSpacing.radiusMd)),
+            shape: _snackBarShape,
           ),
         );
       }
@@ -157,7 +158,7 @@ class QuickActions extends StatelessWidget {
           content: Text(e.toString()),
           backgroundColor: Theme.of(context).colorScheme.error,
           behavior: SnackBarBehavior.floating,
-          shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(ValoraSpacing.radiusMd)),
+          shape: _snackBarShape,
         ),
       );
     } on ValoraPermissionDeniedException catch (e) {
@@ -169,7 +170,7 @@ class QuickActions extends StatelessWidget {
           content: Text(e.toString()),
           backgroundColor: Theme.of(context).colorScheme.error,
           behavior: SnackBarBehavior.floating,
-          shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(ValoraSpacing.radiusMd)),
+          shape: _snackBarShape,
         ),
       );
     } on ValoraPermissionDeniedForeverException catch (e) {
@@ -181,7 +182,7 @@ class QuickActions extends StatelessWidget {
           content: Text(e.toString()),
           backgroundColor: Theme.of(context).colorScheme.error,
           behavior: SnackBarBehavior.floating,
-          shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(ValoraSpacing.radiusMd)),
+          shape: _snackBarShape,
         ),
       );
     } catch (e, stackTrace) {
@@ -193,7 +194,7 @@ class QuickActions extends StatelessWidget {
           content: const Text('Could not determine location.'),
           backgroundColor: Theme.of(context).colorScheme.error,
           behavior: SnackBarBehavior.floating,
-          shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(ValoraSpacing.radiusMd)),
+          shape: _snackBarShape,
         ),
       );
     }

--- a/apps/flutter_app/lib/screens/context_report/widgets/quick_actions.dart
+++ b/apps/flutter_app/lib/screens/context_report/widgets/quick_actions.dart
@@ -23,8 +23,9 @@ class QuickActions extends StatelessWidget {
   final TextEditingController controller;
   final LocationService _locationService;
 
-  static final _snackBarShape =
-      RoundedRectangleBorder(borderRadius: BorderRadius.circular(ValoraSpacing.radiusMd));
+  static const _snackBarShape = RoundedRectangleBorder(
+    borderRadius: BorderRadius.all(Radius.circular(ValoraSpacing.radiusMd)),
+  );
 
   Future<void> _pickLocation(BuildContext context) async {
     final LatLng? result = await Navigator.push<LatLng>(

--- a/apps/flutter_app/lib/screens/context_report/widgets/quick_actions.dart
+++ b/apps/flutter_app/lib/screens/context_report/widgets/quick_actions.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:latlong2/latlong.dart';
 import '../../../widgets/valora_widgets.dart';
 import '../../../widgets/report/location_picker.dart';
+import '../../../core/theme/valora_spacing.dart';
 import '../../../services/pdok_service.dart';
 import '../../../services/location_service.dart';
 import '../../../providers/context_report_provider.dart';
@@ -36,7 +37,7 @@ class QuickActions extends StatelessWidget {
           duration: const Duration(seconds: 1),
           behavior: SnackBarBehavior.floating,
           shape:
-              RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+              RoundedRectangleBorder(borderRadius: BorderRadius.circular(ValoraSpacing.radiusMd)),
         ),
       );
 
@@ -58,7 +59,7 @@ class QuickActions extends StatelessWidget {
               backgroundColor: Theme.of(context).colorScheme.error,
               behavior: SnackBarBehavior.floating,
               shape: RoundedRectangleBorder(
-                  borderRadius: BorderRadius.circular(12)),
+                  borderRadius: BorderRadius.circular(ValoraSpacing.radiusMd)),
             ),
           );
         }
@@ -71,7 +72,7 @@ class QuickActions extends StatelessWidget {
             content: const Text('Could not determine location.'),
             backgroundColor: Theme.of(context).colorScheme.error,
             behavior: SnackBarBehavior.floating,
-            shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+            shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(ValoraSpacing.radiusMd)),
           ),
         );
       }
@@ -84,7 +85,7 @@ class QuickActions extends StatelessWidget {
         content: const Text('Getting location…'),
         duration: const Duration(seconds: 1),
         behavior: SnackBarBehavior.floating,
-        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(ValoraSpacing.radiusMd)),
       ),
     );
 
@@ -98,7 +99,7 @@ class QuickActions extends StatelessWidget {
           content: const Text('Resolving address…'),
           duration: const Duration(seconds: 1),
           behavior: SnackBarBehavior.floating,
-          shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+          shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(ValoraSpacing.radiusMd)),
         ),
       );
 
@@ -130,7 +131,7 @@ class QuickActions extends StatelessWidget {
               content: const Text('Could not resolve an address for your location.'),
               backgroundColor: Theme.of(context).colorScheme.error,
               behavior: SnackBarBehavior.floating,
-              shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+              shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(ValoraSpacing.radiusMd)),
             ),
           );
         }
@@ -143,7 +144,7 @@ class QuickActions extends StatelessWidget {
             content: const Text('Could not determine location.'),
             backgroundColor: Theme.of(context).colorScheme.error,
             behavior: SnackBarBehavior.floating,
-            shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+            shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(ValoraSpacing.radiusMd)),
           ),
         );
       }
@@ -156,7 +157,7 @@ class QuickActions extends StatelessWidget {
           content: Text(e.toString()),
           backgroundColor: Theme.of(context).colorScheme.error,
           behavior: SnackBarBehavior.floating,
-          shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+          shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(ValoraSpacing.radiusMd)),
         ),
       );
     } on ValoraPermissionDeniedException catch (e) {
@@ -168,7 +169,7 @@ class QuickActions extends StatelessWidget {
           content: Text(e.toString()),
           backgroundColor: Theme.of(context).colorScheme.error,
           behavior: SnackBarBehavior.floating,
-          shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+          shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(ValoraSpacing.radiusMd)),
         ),
       );
     } on ValoraPermissionDeniedForeverException catch (e) {
@@ -180,7 +181,7 @@ class QuickActions extends StatelessWidget {
           content: Text(e.toString()),
           backgroundColor: Theme.of(context).colorScheme.error,
           behavior: SnackBarBehavior.floating,
-          shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+          shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(ValoraSpacing.radiusMd)),
         ),
       );
     } catch (e, stackTrace) {
@@ -192,7 +193,7 @@ class QuickActions extends StatelessWidget {
           content: const Text('Could not determine location.'),
           backgroundColor: Theme.of(context).colorScheme.error,
           behavior: SnackBarBehavior.floating,
-          shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+          shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(ValoraSpacing.radiusMd)),
         ),
       );
     }
@@ -201,8 +202,8 @@ class QuickActions extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Wrap(
-      spacing: 12,
-      runSpacing: 12,
+      spacing: ValoraSpacing.md,
+      runSpacing: ValoraSpacing.md,
       children: [
         ValoraButton(
           label: 'Pick on Map',

--- a/apps/flutter_app/lib/screens/context_report/widgets/radius_selector.dart
+++ b/apps/flutter_app/lib/screens/context_report/widgets/radius_selector.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import '../../../widgets/valora_widgets.dart';
 import '../../../core/theme/valora_typography.dart';
+import '../../../core/theme/valora_spacing.dart';
 import '../../../providers/context_report_provider.dart';
 
 class RadiusSelector extends StatelessWidget {
@@ -12,7 +13,8 @@ class RadiusSelector extends StatelessWidget {
     final theme = Theme.of(context);
 
     return ValoraCard(
-      padding: const EdgeInsets.fromLTRB(20, 16, 20, 12),
+      elevation: ValoraSpacing.elevationSm,
+      padding: const EdgeInsets.all(ValoraSpacing.md),
       onTap: null, // Keep card interactive setup
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
@@ -27,7 +29,7 @@ class RadiusSelector extends StatelessWidget {
                     size: 18,
                     color: theme.colorScheme.onSurfaceVariant,
                   ),
-                  const SizedBox(width: 8),
+                  const SizedBox(width: ValoraSpacing.sm),
                   Text(
                     'Analysis Radius',
                     style: ValoraTypography.labelLarge
@@ -47,7 +49,7 @@ class RadiusSelector extends StatelessWidget {
               ),
             ],
           ),
-          const SizedBox(height: 8),
+          const SizedBox(height: ValoraSpacing.sm),
           Selector<ContextReportProvider, int>(
             selector: (_, p) => p.radiusMeters,
             builder: (context, radiusMeters, _) {

--- a/apps/flutter_app/lib/screens/context_report/widgets/saved_searches_section.dart
+++ b/apps/flutter_app/lib/screens/context_report/widgets/saved_searches_section.dart
@@ -3,6 +3,7 @@ import 'package:provider/provider.dart';
 import 'package:intl/intl.dart';
 import '../../../widgets/valora_widgets.dart';
 import '../../../core/theme/valora_typography.dart';
+import '../../../core/theme/valora_spacing.dart';
 import 'package:flutter_animate/flutter_animate.dart';
 import '../../../providers/context_report_provider.dart';
 import '../../../models/saved_search.dart';
@@ -26,18 +27,19 @@ class SavedSearchesSection extends StatelessWidget {
       builder: (context, savedSearches, _) {
         if (savedSearches.isEmpty) return const SizedBox.shrink();
         return Padding(
-          padding: const EdgeInsets.fromLTRB(20, 0, 20, 0), // Adjust padding as needed
+          padding: const EdgeInsets.symmetric(horizontal: ValoraSpacing.lg),
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
               const ValoraSectionHeader(title: 'Saved Searches'),
-              const SizedBox(height: 12),
+              const SizedBox(height: ValoraSpacing.sm),
               ...savedSearches.asMap().entries.map((entry) {
                 final index = entry.key;
                 final item = entry.value;
                 return Padding(
-                  padding: const EdgeInsets.only(bottom: 8),
+                  padding: const EdgeInsets.only(bottom: ValoraSpacing.sm),
                   child: ValoraCard(
+                    elevation: ValoraSpacing.elevationSm,
                     onTap: provider.isLoading
                         ? null
                         : () {
@@ -45,12 +47,11 @@ class SavedSearchesSection extends StatelessWidget {
                             provider.setRadiusMeters(item.radiusMeters);
                             provider.generate(item.query);
                           },
-                    padding: const EdgeInsets.symmetric(
-                        horizontal: 16, vertical: 14),
+                    padding: const EdgeInsets.all(ValoraSpacing.md),
                     child: Row(
                       children: [
                         Container(
-                          padding: const EdgeInsets.all(8),
+                          padding: const EdgeInsets.all(ValoraSpacing.sm),
                           decoration: BoxDecoration(
                             color: theme.colorScheme.primary
                                 .withValues(alpha: 0.08),
@@ -58,11 +59,11 @@ class SavedSearchesSection extends StatelessWidget {
                           ),
                           child: Icon(
                             Icons.bookmark_rounded,
-                            size: 16,
+                            size: ValoraSpacing.iconSizeSm,
                             color: theme.colorScheme.primary,
                           ),
                         ),
-                        const SizedBox(width: 14),
+                        const SizedBox(width: ValoraSpacing.md),
                         Expanded(
                           child: Column(
                             crossAxisAlignment: CrossAxisAlignment.start,
@@ -75,7 +76,7 @@ class SavedSearchesSection extends StatelessWidget {
                                   fontWeight: FontWeight.w600,
                                 ),
                               ),
-                              const SizedBox(height: 2),
+                              const SizedBox(height: ValoraSpacing.xs),
                               Text(
                                 '${item.radiusMeters}m radius • ${_formatDate(item.createdAt)}',
                                 style: ValoraTypography.labelSmall.copyWith(
@@ -92,7 +93,7 @@ class SavedSearchesSection extends StatelessWidget {
                             item.isAlertEnabled
                                 ? Icons.notifications_active_rounded
                                 : Icons.notifications_none_rounded,
-                            size: 20,
+                            size: ValoraSpacing.iconSizeMd,
                             color: item.isAlertEnabled
                                 ? theme.colorScheme.primary
                                 : theme.colorScheme.onSurfaceVariant,
@@ -104,7 +105,7 @@ class SavedSearchesSection extends StatelessWidget {
                           tooltip: 'Remove',
                           icon: Icon(
                             Icons.close_rounded,
-                            size: 18,
+                            size: ValoraSpacing.iconSizeMd,
                             color: theme.colorScheme.onSurfaceVariant,
                           ),
                           onPressed: () => _confirmRemove(context, provider, item),


### PR DESCRIPTION
This PR replaces hardcoded numeric values for padding, margins, border radii, and icon sizes across several widgets in the Flutter application with standard design tokens from `ValoraSpacing`. It introduces consistent `ValoraCard` elevation to improve shadow representation.

Key changes:
- `SearchLayout`: Snapped margins, padding, and specific box sizing attributes to correct `ValoraSpacing` values. Reverted explicit branding row shadows to standard integers since they don't map to predefined generic tokens yet.
- `QuickActions`: Updated `Wrap` spacing properties and `SnackBar` border-radius to use `ValoraSpacing.md` and `ValoraSpacing.radiusMd`.
- `RadiusSelector`: Substituted generic numeric constraints with standard tokens and added small elevation to the card to give it a premium feel.
- `HistorySection` & `SavedSearchesSection`: Converted spacing and sizing metrics to `ValoraSpacing` values while eliminating complex token arithmetic calculations.

All changes were verified using `flutter test --coverage` confirming no regressions were introduced.

---
*PR created automatically by Jules for task [9776500170518762087](https://jules.google.com/task/9776500170518762087) started by @YKDBontekoe*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Unified spacing, padding, and sizing across context report screens to align with the design system tokens.
  * Standardized card elevations, snackbar shape, icon sizes, and border radii for a cohesive visual hierarchy.
  * Updated layouts for search, history, quick actions, radius selector, and saved searches to use consistent spacing tokens without changing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->