### PR TITLE
feat: add active jobs count to admin stats overview

### DIFF
--- a/backend/Valora.Application/Common/Interfaces/IBatchJobRepository.cs
+++ b/backend/Valora.Application/Common/Interfaces/IBatchJobRepository.cs
@@ -25,4 +25,5 @@ public interface IBatchJobRepository
     Task<BatchJob> AddAsync(BatchJob job, CancellationToken cancellationToken = default);
     Task<BatchJobStatus?> GetStatusAsync(Guid id, CancellationToken cancellationToken = default);
     Task UpdateAsync(BatchJob job, CancellationToken cancellationToken = default);
+    Task<int> GetActiveJobCountAsync(CancellationToken cancellationToken = default);
 }

--- a/backend/Valora.Application/DTOs/AdminDtos.cs
+++ b/backend/Valora.Application/DTOs/AdminDtos.cs
@@ -11,7 +11,8 @@ public record AdminUserDto(
 
 public record AdminStatsDto(
     int TotalUsers,
-    int TotalNotifications
+    int TotalNotifications,
+    int ActiveJobs
 );
 
 public record BatchJobRequest(

--- a/backend/Valora.Application/Services/AdminService.cs
+++ b/backend/Valora.Application/Services/AdminService.cs
@@ -11,17 +11,20 @@ public class AdminService : IAdminService
     private readonly IIdentityService _identityService;
     private readonly INotificationRepository _notificationRepository;
     private readonly INeighborhoodRepository _neighborhoodRepository;
+    private readonly IBatchJobRepository _batchJobRepository;
     private readonly ILogger<AdminService> _logger;
 
     public AdminService(
         IIdentityService identityService,
         INotificationRepository notificationRepository,
         INeighborhoodRepository neighborhoodRepository,
+        IBatchJobRepository batchJobRepository,
         ILogger<AdminService> logger)
     {
         _identityService = identityService;
         _notificationRepository = notificationRepository;
         _neighborhoodRepository = neighborhoodRepository;
+        _batchJobRepository = batchJobRepository;
         _logger = logger;
     }
 
@@ -89,8 +92,9 @@ public class AdminService : IAdminService
 
         var usersCount = await _identityService.CountAsync();
         var notificationsCount = await _notificationRepository.CountAsync();
+        var activeJobs = await _batchJobRepository.GetActiveJobCountAsync();
 
-        return new AdminStatsDto(usersCount, notificationsCount);
+        return new AdminStatsDto(usersCount, notificationsCount, activeJobs);
     }
 
     public async Task<List<DatasetStatusDto>> GetDatasetStatusAsync(CancellationToken cancellationToken = default)

--- a/backend/Valora.Infrastructure/Persistence/Repositories/BatchJobRepository.cs
+++ b/backend/Valora.Infrastructure/Persistence/Repositories/BatchJobRepository.cs
@@ -197,4 +197,10 @@ public class BatchJobRepository : IBatchJobRepository
         _context.Entry(job).State = EntityState.Modified;
         await _context.SaveChangesAsync(cancellationToken);
     }
+
+    public async Task<int> GetActiveJobCountAsync(CancellationToken cancellationToken = default)
+    {
+        return await _context.BatchJobs
+            .CountAsync(j => j.Status == BatchJobStatus.Processing || j.Status == BatchJobStatus.Pending, cancellationToken);
+    }
 }

--- a/backend/Valora.UnitTests/Repositories/BatchJobRepositoryTests.cs
+++ b/backend/Valora.UnitTests/Repositories/BatchJobRepositoryTests.cs
@@ -217,4 +217,26 @@ public class BatchJobRepositoryTests
         Assert.Single(result.Items);
         Assert.Equal("Amsterdam", result.Items[0].Target);
     }
+
+    [Fact]
+    public async Task GetActiveJobCountAsync_ShouldCountOnlyPendingAndProcessing()
+    {
+        // Arrange
+        using var context = new ValoraDbContext(_options);
+        await SeedDatabase(context);
+        var repository = new BatchJobRepository(context);
+
+        // SeedDatabase includes:
+        // 1 Completed (Amsterdam)
+        // 1 Processing (Rotterdam)
+        // 1 Pending (Utrecht)
+        // 1 Failed (Netherlands)
+
+        // Act
+        var activeCount = await repository.GetActiveJobCountAsync();
+
+        // Assert
+        // We expect exactly 2 active jobs (1 Pending + 1 Processing)
+        Assert.Equal(2, activeCount);
+    }
 }

--- a/backend/Valora.UnitTests/Services/AdminServiceTests.cs
+++ b/backend/Valora.UnitTests/Services/AdminServiceTests.cs
@@ -14,6 +14,7 @@ public class AdminServiceTests
     private readonly Mock<IIdentityService> _identityServiceMock = new();
     private readonly Mock<INotificationRepository> _notificationRepositoryMock = new();
     private readonly Mock<INeighborhoodRepository> _neighborhoodRepositoryMock = new();
+    private readonly Mock<IBatchJobRepository> _batchJobRepositoryMock = new();
     private readonly Mock<ILogger<AdminService>> _loggerMock = new();
 
     private AdminService CreateService()
@@ -22,6 +23,7 @@ public class AdminServiceTests
             _identityServiceMock.Object,
             _notificationRepositoryMock.Object,
             _neighborhoodRepositoryMock.Object,
+            _batchJobRepositoryMock.Object,
             _loggerMock.Object);
     }
 
@@ -124,6 +126,7 @@ public class AdminServiceTests
 
         _identityServiceMock.Setup(x => x.CountAsync()).ReturnsAsync(10);
         _notificationRepositoryMock.Setup(x => x.CountAsync()).ReturnsAsync(5);
+        _batchJobRepositoryMock.Setup(x => x.GetActiveJobCountAsync(It.IsAny<CancellationToken>())).ReturnsAsync(2);
 
         // Act
         var result = await service.GetSystemStatsAsync();
@@ -131,6 +134,7 @@ public class AdminServiceTests
         // Assert
         Assert.Equal(10, result.TotalUsers);
         Assert.Equal(5, result.TotalNotifications);
+        Assert.Equal(2, result.ActiveJobs);
     }
 
     [Fact]


### PR DESCRIPTION
This PR enhances the admin dashboard stats overview by adding the `activeJobs` field. It allows administrators to see the current count of pending or processing batch jobs. The logic correctly adds a new repository method to count `BatchJobStatus.Processing` and `BatchJobStatus.Pending` jobs, passes this to the `AdminStatsDto`, and tests the modified service layer.

---
*PR created automatically by Jules for task [10383482427639965220](https://jules.google.com/task/10383482427639965220) started by @YKDBontekoe*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Admin statistics now include active batch job count, showing how many jobs are currently processing or pending for improved dashboard visibility.

* **Tests**
  * Updated admin service tests to validate active job reporting.
  * Added repository-level test to ensure only processing and pending jobs are counted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->