### PR TITLE
refactor: Move INotificationService to Common/Interfaces

### DIFF
--- a/backend/Valora.Api/Endpoints/NotificationEndpoints.cs
+++ b/backend/Valora.Api/Endpoints/NotificationEndpoints.cs
@@ -1,3 +1,4 @@
+using Valora.Application.Common.Interfaces;
 using System.Security.Claims;
 using Microsoft.AspNetCore.Mvc;
 using Valora.Application.Services;

--- a/backend/Valora.Api/Endpoints/NotificationEndpoints.cs
+++ b/backend/Valora.Api/Endpoints/NotificationEndpoints.cs
@@ -1,7 +1,6 @@
 using Valora.Application.Common.Interfaces;
 using System.Security.Claims;
 using Microsoft.AspNetCore.Mvc;
-using Valora.Application.Services;
 using Valora.Domain.Enums;
 
 namespace Valora.Api.Endpoints;

--- a/backend/Valora.Application/Common/Interfaces/INotificationService.cs
+++ b/backend/Valora.Application/Common/Interfaces/INotificationService.cs
@@ -4,7 +4,7 @@ using System.Threading.Tasks;
 using Valora.Application.DTOs;
 using Valora.Domain.Enums;
 
-namespace Valora.Application.Services;
+namespace Valora.Application.Common.Interfaces;
 
 public interface INotificationService
 {

--- a/backend/Valora.Infrastructure/Services/NotificationEventHandlers.cs
+++ b/backend/Valora.Infrastructure/Services/NotificationEventHandlers.cs
@@ -1,4 +1,3 @@
-using Valora.Application.Services;
 using System;
 using System.Threading;
 using System.Threading.Tasks;

--- a/backend/Valora.UnitTests/Services/NotificationServiceTests.cs
+++ b/backend/Valora.UnitTests/Services/NotificationServiceTests.cs
@@ -6,6 +6,7 @@ using Valora.Infrastructure.Persistence;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Time.Testing;
 using Moq;
+using Valora.Application.Common.Interfaces;
 using Valora.Application.Services;
 using Valora.Infrastructure.Persistence.Repositories;
 using Xunit;


### PR DESCRIPTION
- Relocated `INotificationService.cs` from `Valora.Application/Services/` to `Valora.Application/Common/Interfaces/`.
- Updated the namespace to `Valora.Application.Common.Interfaces`.
- Added required using directives to `NotificationEndpoints.cs`.
- Verified the build and ran integration/unit tests to ensure no regressions.

---
*PR created automatically by Jules for task [16808694224724318001](https://jules.google.com/task/16808694224724318001) started by @YKDBontekoe*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Reorganized an internal notification interface location and updated related references; no user-facing behavior or API changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->