### PR TITLE
refactor(cbs-geo): rename vague variable to express intent explicitly

### DIFF
--- a/backend/Valora.Infrastructure/Enrichment/CbsGeoClient.cs
+++ b/backend/Valora.Infrastructure/Enrichment/CbsGeoClient.cs
@@ -269,10 +269,10 @@ public sealed class CbsGeoClient : ICbsGeoClient
                 }
 
                 using var content = await response.Content.ReadAsStreamAsync(cancellationToken);
-                var xdoc = await System.Xml.Linq.XDocument.LoadAsync(content, System.Xml.Linq.LoadOptions.None, cancellationToken);
+                var xmlDocument = await System.Xml.Linq.XDocument.LoadAsync(content, System.Xml.Linq.LoadOptions.None, cancellationToken);
 
                 var wijkenbuurten = System.Xml.Linq.XNamespace.Get("http://wijkenbuurten.geonovum.nl");
-                var elements = xdoc.Descendants(wijkenbuurten + "gemeentenaam");
+                var elements = xmlDocument.Descendants(wijkenbuurten + "gemeentenaam");
 
                 var results = new HashSet<string>();
                 foreach (var element in elements)


### PR DESCRIPTION
This PR implements a minor code quality refactoring:

- Renamed the variable `xdoc` to `xmlDocument` in `backend/Valora.Infrastructure/Enrichment/CbsGeoClient.cs` to improve clarity and express intent explicitly.

This is in line with the codebase maintainability directive to continuously improve code quality without changing functionality. All tests pass successfully.

---
*PR created automatically by Jules for task [15252523283351204286](https://jules.google.com/task/15252523283351204286) started by @YKDBontekoe*