### PR TITLE
Refactor `WorkspaceEndpoints.cs` for maintainability

### DIFF
--- a/backend/Valora.Api/Endpoints/WorkspaceEndpoints.cs
+++ b/backend/Valora.Api/Endpoints/WorkspaceEndpoints.cs
@@ -20,26 +20,6 @@ public static class WorkspaceEndpoints
         group.MapGet("/", GetUserWorkspaces);
         group.MapGet("/{id}", GetWorkspace);
         group.MapDelete("/{id}", DeleteWorkspace);
-
-        group.MapGet("/{id}/members", GetMembers);
-        group.MapPost("/{id}/members", InviteMember)
-            .AddEndpointFilter<Valora.Api.Filters.ValidationFilter<InviteMemberDto>>();
-
-        group.MapDelete("/{id}/members/{memberId}", RemoveMember);
-
-        group.MapGet("/{id}/properties", GetSavedProperties);
-        group.MapPost("/{id}/properties", SaveProperty)
-            .AddEndpointFilter<Valora.Api.Filters.ValidationFilter<SavePropertyDto>>();
-
-        group.MapPost("/{id}/properties/from-report", SavePropertyFromReport)
-            .AddEndpointFilter<Valora.Api.Filters.ValidationFilter<SavePropertyFromReportDto>>();
-
-        group.MapDelete("/{id}/properties/{savedPropertyId}", RemoveSavedProperty);
-
-        group.MapGet("/{id}/properties/{savedPropertyId}/comments", GetComments);
-        group.MapPost("/{id}/properties/{savedPropertyId}/comments", AddComment)
-            .AddEndpointFilter<Valora.Api.Filters.ValidationFilter<AddCommentDto>>();
-
         group.MapGet("/{id}/activity", GetActivityLogs);
 
         return group;
@@ -106,141 +86,6 @@ public static class WorkspaceEndpoints
         return Results.NoContent();
     }
 
-    private static async Task<IResult> GetMembers(
-        ClaimsPrincipal user,
-        Guid id,
-        IWorkspaceMemberService service,
-        CancellationToken ct)
-    {
-        var userId = user.FindFirstValue(ClaimTypes.NameIdentifier);
-        if (userId == null) return Results.Unauthorized();
-
-        var result = await service.GetMembersAsync(userId, id, ct);
-        return Results.Ok(result);
-    }
-
-    private static async Task<IResult> InviteMember(
-        ClaimsPrincipal user,
-        Guid id,
-        [FromBody] InviteMemberDto dto,
-        IWorkspaceMemberService service,
-        CancellationToken ct)
-    {
-        var userId = user.FindFirstValue(ClaimTypes.NameIdentifier);
-        if (userId == null) return Results.Unauthorized();
-
-        await service.AddMemberAsync(userId, id, dto, ct);
-        return Results.Ok();
-    }
-
-    private static async Task<IResult> RemoveMember(
-        ClaimsPrincipal user,
-        Guid id,
-        Guid memberId,
-        IWorkspaceMemberService service,
-        CancellationToken ct)
-    {
-        var userId = user.FindFirstValue(ClaimTypes.NameIdentifier);
-        if (userId == null) return Results.Unauthorized();
-
-        await service.RemoveMemberAsync(userId, id, memberId, ct);
-        return Results.NoContent();
-    }
-
-    private static async Task<IResult> GetSavedProperties(
-        ClaimsPrincipal user,
-        Guid id,
-        IWorkspacePropertyService service,
-        CancellationToken ct)
-    {
-        var userId = user.FindFirstValue(ClaimTypes.NameIdentifier);
-        if (userId == null) return Results.Unauthorized();
-
-        var result = await service.GetSavedPropertiesAsync(userId, id, ct);
-        return Results.Ok(result);
-    }
-
-    private static async Task<IResult> SaveProperty(
-        ClaimsPrincipal user,
-        Guid id,
-        [FromBody] SavePropertyDto request,
-        IWorkspacePropertyService service,
-        CancellationToken ct)
-    {
-        var userId = user.FindFirstValue(ClaimTypes.NameIdentifier);
-        if (userId == null) return Results.Unauthorized();
-
-        var result = await service.SavePropertyAsync(userId, id, request.PropertyId, request.Notes, ct);
-        return Results.Ok(result);
-    }
-
-    /// <summary>
-    /// Saves a newly generated Context Report directly to a Workspace.
-    /// </summary>
-    /// <remarks>
-    /// <para>
-    /// <strong>Why save reports?</strong> Context reports are dynamically generated in real-time ("Fan-Out").
-    /// Saving a report to a workspace takes a "snapshot" of the data and persists it to the database,
-    /// allowing users to revisit the exact stats, share them with team members, and add comments.
-    /// </para>
-    /// </remarks>
-    private static async Task<IResult> SavePropertyFromReport(
-        ClaimsPrincipal user,
-        Guid id,
-        [FromBody] SavePropertyFromReportDto request,
-        IWorkspacePropertyService service,
-        CancellationToken ct)
-    {
-        var userId = user.FindFirstValue(ClaimTypes.NameIdentifier);
-        if (userId == null) return Results.Unauthorized();
-
-        var result = await service.SaveContextReportAsync(userId, id, request.Report, request.Notes, ct);
-        return Results.Ok(result);
-    }
-
-    private static async Task<IResult> RemoveSavedProperty(
-        ClaimsPrincipal user,
-        Guid id,
-        Guid savedPropertyId,
-        IWorkspacePropertyService service,
-        CancellationToken ct)
-    {
-        var userId = user.FindFirstValue(ClaimTypes.NameIdentifier);
-        if (userId == null) return Results.Unauthorized();
-
-        await service.RemoveSavedPropertyAsync(userId, id, savedPropertyId, ct);
-        return Results.NoContent();
-    }
-
-    private static async Task<IResult> GetComments(
-        ClaimsPrincipal user,
-        Guid id,
-        Guid savedPropertyId,
-        IWorkspacePropertyService service,
-        CancellationToken ct)
-    {
-        var userId = user.FindFirstValue(ClaimTypes.NameIdentifier);
-        if (userId == null) return Results.Unauthorized();
-
-        var result = await service.GetCommentsAsync(userId, id, savedPropertyId, ct);
-        return Results.Ok(result);
-    }
-
-    private static async Task<IResult> AddComment(
-        ClaimsPrincipal user,
-        Guid id,
-        Guid savedPropertyId,
-        [FromBody] AddCommentDto dto,
-        IWorkspacePropertyService service,
-        CancellationToken ct)
-    {
-        var userId = user.FindFirstValue(ClaimTypes.NameIdentifier);
-        if (userId == null) return Results.Unauthorized();
-
-        var result = await service.AddCommentAsync(userId, id, savedPropertyId, dto, ct);
-        return Results.Ok(result);
-    }
-
     private static async Task<IResult> GetActivityLogs(
         ClaimsPrincipal user,
         Guid id,
@@ -253,5 +98,4 @@ public static class WorkspaceEndpoints
         var result = await service.GetActivityLogsAsync(userId, id, ct);
         return Results.Ok(result);
     }
-
 }

--- a/backend/Valora.Api/Endpoints/WorkspaceMemberEndpoints.cs
+++ b/backend/Valora.Api/Endpoints/WorkspaceMemberEndpoints.cs
@@ -1,0 +1,66 @@
+using System.Security.Claims;
+using Microsoft.AspNetCore.Mvc;
+using Valora.Application.Common.Interfaces;
+using Valora.Application.DTOs;
+
+namespace Valora.Api.Endpoints;
+
+public static class WorkspaceMemberEndpoints
+{
+    public static RouteGroupBuilder MapWorkspaceMemberEndpoints(this IEndpointRouteBuilder routes)
+    {
+        var group = routes.MapGroup("/api/workspaces")
+            .RequireAuthorization()
+            .RequireRateLimiting(Valora.Api.Constants.RateLimitPolicies.Fixed)
+            .WithTags("Workspace Members");
+
+        group.MapGet("/{id}/members", GetMembers);
+        group.MapPost("/{id}/members", InviteMember)
+            .AddEndpointFilter<Valora.Api.Filters.ValidationFilter<InviteMemberDto>>();
+
+        group.MapDelete("/{id}/members/{memberId}", RemoveMember);
+
+        return group;
+    }
+
+    private static async Task<IResult> GetMembers(
+        ClaimsPrincipal user,
+        Guid id,
+        IWorkspaceMemberService service,
+        CancellationToken ct)
+    {
+        var userId = user.FindFirstValue(ClaimTypes.NameIdentifier);
+        if (userId == null) return Results.Unauthorized();
+
+        var result = await service.GetMembersAsync(userId, id, ct);
+        return Results.Ok(result);
+    }
+
+    private static async Task<IResult> InviteMember(
+        ClaimsPrincipal user,
+        Guid id,
+        [FromBody] InviteMemberDto dto,
+        IWorkspaceMemberService service,
+        CancellationToken ct)
+    {
+        var userId = user.FindFirstValue(ClaimTypes.NameIdentifier);
+        if (userId == null) return Results.Unauthorized();
+
+        await service.AddMemberAsync(userId, id, dto, ct);
+        return Results.Ok();
+    }
+
+    private static async Task<IResult> RemoveMember(
+        ClaimsPrincipal user,
+        Guid id,
+        Guid memberId,
+        IWorkspaceMemberService service,
+        CancellationToken ct)
+    {
+        var userId = user.FindFirstValue(ClaimTypes.NameIdentifier);
+        if (userId == null) return Results.Unauthorized();
+
+        await service.RemoveMemberAsync(userId, id, memberId, ct);
+        return Results.NoContent();
+    }
+}

--- a/backend/Valora.Api/Endpoints/WorkspacePropertyEndpoints.cs
+++ b/backend/Valora.Api/Endpoints/WorkspacePropertyEndpoints.cs
@@ -1,0 +1,126 @@
+using System.Security.Claims;
+using Microsoft.AspNetCore.Mvc;
+using Valora.Application.Common.Interfaces;
+using Valora.Application.DTOs;
+
+namespace Valora.Api.Endpoints;
+
+public static class WorkspacePropertyEndpoints
+{
+    public static RouteGroupBuilder MapWorkspacePropertyEndpoints(this IEndpointRouteBuilder routes)
+    {
+        var group = routes.MapGroup("/api/workspaces")
+            .RequireAuthorization()
+            .RequireRateLimiting(Valora.Api.Constants.RateLimitPolicies.Fixed)
+            .WithTags("Workspace Properties");
+
+        group.MapGet("/{id}/properties", GetSavedProperties);
+        group.MapPost("/{id}/properties", SaveProperty)
+            .AddEndpointFilter<Valora.Api.Filters.ValidationFilter<SavePropertyDto>>();
+
+        group.MapPost("/{id}/properties/from-report", SavePropertyFromReport)
+            .AddEndpointFilter<Valora.Api.Filters.ValidationFilter<SavePropertyFromReportDto>>();
+
+        group.MapDelete("/{id}/properties/{savedPropertyId}", RemoveSavedProperty);
+
+        group.MapGet("/{id}/properties/{savedPropertyId}/comments", GetComments);
+        group.MapPost("/{id}/properties/{savedPropertyId}/comments", AddComment)
+            .AddEndpointFilter<Valora.Api.Filters.ValidationFilter<AddCommentDto>>();
+
+        return group;
+    }
+
+    private static async Task<IResult> GetSavedProperties(
+        ClaimsPrincipal user,
+        Guid id,
+        IWorkspacePropertyService service,
+        CancellationToken ct)
+    {
+        var userId = user.FindFirstValue(ClaimTypes.NameIdentifier);
+        if (userId == null) return Results.Unauthorized();
+
+        var result = await service.GetSavedPropertiesAsync(userId, id, ct);
+        return Results.Ok(result);
+    }
+
+    private static async Task<IResult> SaveProperty(
+        ClaimsPrincipal user,
+        Guid id,
+        [FromBody] SavePropertyDto request,
+        IWorkspacePropertyService service,
+        CancellationToken ct)
+    {
+        var userId = user.FindFirstValue(ClaimTypes.NameIdentifier);
+        if (userId == null) return Results.Unauthorized();
+
+        var result = await service.SavePropertyAsync(userId, id, request.PropertyId, request.Notes, ct);
+        return Results.Ok(result);
+    }
+
+    /// <summary>
+    /// Saves a newly generated Context Report directly to a Workspace.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <strong>Why save reports?</strong> Context reports are dynamically generated in real-time ("Fan-Out").
+    /// Saving a report to a workspace takes a "snapshot" of the data and persists it to the database,
+    /// allowing users to revisit the exact stats, share them with team members, and add comments.
+    /// </para>
+    /// </remarks>
+    private static async Task<IResult> SavePropertyFromReport(
+        ClaimsPrincipal user,
+        Guid id,
+        [FromBody] SavePropertyFromReportDto request,
+        IWorkspacePropertyService service,
+        CancellationToken ct)
+    {
+        var userId = user.FindFirstValue(ClaimTypes.NameIdentifier);
+        if (userId == null) return Results.Unauthorized();
+
+        var result = await service.SaveContextReportAsync(userId, id, request.Report, request.Notes, ct);
+        return Results.Ok(result);
+    }
+
+    private static async Task<IResult> RemoveSavedProperty(
+        ClaimsPrincipal user,
+        Guid id,
+        Guid savedPropertyId,
+        IWorkspacePropertyService service,
+        CancellationToken ct)
+    {
+        var userId = user.FindFirstValue(ClaimTypes.NameIdentifier);
+        if (userId == null) return Results.Unauthorized();
+
+        await service.RemoveSavedPropertyAsync(userId, id, savedPropertyId, ct);
+        return Results.NoContent();
+    }
+
+    private static async Task<IResult> GetComments(
+        ClaimsPrincipal user,
+        Guid id,
+        Guid savedPropertyId,
+        IWorkspacePropertyService service,
+        CancellationToken ct)
+    {
+        var userId = user.FindFirstValue(ClaimTypes.NameIdentifier);
+        if (userId == null) return Results.Unauthorized();
+
+        var result = await service.GetCommentsAsync(userId, id, savedPropertyId, ct);
+        return Results.Ok(result);
+    }
+
+    private static async Task<IResult> AddComment(
+        ClaimsPrincipal user,
+        Guid id,
+        Guid savedPropertyId,
+        [FromBody] AddCommentDto dto,
+        IWorkspacePropertyService service,
+        CancellationToken ct)
+    {
+        var userId = user.FindFirstValue(ClaimTypes.NameIdentifier);
+        if (userId == null) return Results.Unauthorized();
+
+        var result = await service.AddCommentAsync(userId, id, savedPropertyId, dto, ct);
+        return Results.Ok(result);
+    }
+}

--- a/backend/Valora.Api/Program.cs
+++ b/backend/Valora.Api/Program.cs
@@ -134,6 +134,8 @@ app.MapMapEndpoints();
 app.MapAdminEndpoints();
 app.MapUserProfileEndpoints();
 app.MapWorkspaceEndpoints();
+app.MapWorkspaceMemberEndpoints();
+app.MapWorkspacePropertyEndpoints();
 app.MapContextReportEndpoints();
 
 // API Endpoints


### PR DESCRIPTION
Refactored `WorkspaceEndpoints.cs` to separate concerns, resulting in `WorkspaceEndpoints.cs`, `WorkspaceMemberEndpoints.cs`, and `WorkspacePropertyEndpoints.cs`. This significantly improves the readability and maintainability of the codebase. Registered the new endpoint groups in `Program.cs` and verified compilation and test success.

---
*PR created automatically by Jules for task [856456069989791019](https://jules.google.com/task/856456069989791019) started by @YKDBontekoe*