### PR TITLE
Enforce Clean Architecture: Move Application Service Implementations to Infrastructure

### DIFF
--- a/backend/Valora.Api/Endpoints/NotificationEndpoints.cs
+++ b/backend/Valora.Api/Endpoints/NotificationEndpoints.cs
@@ -1,6 +1,6 @@
 using System.Security.Claims;
 using Microsoft.AspNetCore.Mvc;
-using Valora.Application.Services;
+using Valora.Application.Common.Interfaces;
 using Valora.Domain.Enums;
 
 namespace Valora.Api.Endpoints;

--- a/backend/Valora.Application/Common/Interfaces/IBatchJobProcessor.cs
+++ b/backend/Valora.Application/Common/Interfaces/IBatchJobProcessor.cs
@@ -1,7 +1,7 @@
 using Valora.Domain.Entities;
 using Valora.Domain.Enums;
 
-namespace Valora.Application.Services.BatchJobs;
+namespace Valora.Application.Common.Interfaces;
 
 public interface IBatchJobProcessor
 {

--- a/backend/Valora.Application/Common/Interfaces/INotificationService.cs
+++ b/backend/Valora.Application/Common/Interfaces/INotificationService.cs
@@ -4,7 +4,7 @@ using System.Threading.Tasks;
 using Valora.Application.DTOs;
 using Valora.Domain.Enums;
 
-namespace Valora.Application.Services;
+namespace Valora.Application.Common.Interfaces;
 
 public interface INotificationService
 {

--- a/backend/Valora.Application/DependencyInjection.cs
+++ b/backend/Valora.Application/DependencyInjection.cs
@@ -1,7 +1,4 @@
 using Microsoft.Extensions.DependencyInjection;
-using Valora.Application.Common.Interfaces;
-using Valora.Application.Services;
-using Valora.Application.Services.BatchJobs;
 
 namespace Valora.Application;
 
@@ -9,25 +6,6 @@ public static class DependencyInjection
 {
     public static IServiceCollection AddApplication(this IServiceCollection services)
     {
-        services.AddScoped<IAuthService, AuthService>();
-        services.AddScoped<IAdminService, AdminService>();
-        services.AddScoped<INotificationService, NotificationService>();
-        services.AddScoped<IContextReportService, ContextReportService>();
-        services.AddScoped<IContextAnalysisService, ContextAnalysisService>();
-        services.AddScoped<IUserAiProfileService, UserAiProfileService>();
-        services.AddScoped<IContextDataProvider, ContextDataProvider>();
-        services.AddScoped<IMapService, MapService>();
-        services.AddScoped<IBatchJobService, BatchJobService>();
-        services.AddScoped<IBatchJobExecutor, BatchJobExecutor>();
-        services.AddScoped<IWorkspaceService, WorkspaceService>();
-        services.AddScoped<IWorkspaceMemberService, WorkspaceMemberService>();
-        services.AddScoped<IWorkspacePropertyService, WorkspacePropertyService>();
-
-        // Batch Job Processors
-        services.AddScoped<IBatchJobProcessor, CityIngestionJobProcessor>();
-        services.AddScoped<IBatchJobProcessor, MapGenerationJobProcessor>();
-        services.AddScoped<IBatchJobProcessor, AllCitiesIngestionJobProcessor>();
-
         return services;
     }
 }

--- a/backend/Valora.Infrastructure/DependencyInjection.cs
+++ b/backend/Valora.Infrastructure/DependencyInjection.cs
@@ -7,7 +7,7 @@ using Microsoft.Extensions.Options;
 using Valora.Application.Common.Interfaces;
 using Valora.Application.Common.Models;
 using Valora.Application.Enrichment;
-using Valora.Application.Services;
+using Valora.Infrastructure.Services.AppServices;
 using Valora.Infrastructure.Enrichment;
 using Valora.Infrastructure.Persistence;
 using Valora.Infrastructure.Persistence.Repositories;
@@ -34,6 +34,26 @@ public static class DependencyInjection
     {
         // Ensure Logging is available for infrastructure services even in non-web contexts
         services.AddLogging();
+
+        // App Services
+        services.AddScoped<IAuthService, Valora.Infrastructure.Services.AppServices.AuthService>();
+        services.AddScoped<IAdminService, Valora.Infrastructure.Services.AppServices.AdminService>();
+        services.AddScoped<INotificationService, Valora.Infrastructure.Services.AppServices.NotificationService>();
+        services.AddScoped<IContextReportService, Valora.Infrastructure.Services.AppServices.ContextReportService>();
+        services.AddScoped<IContextAnalysisService, Valora.Infrastructure.Services.AppServices.ContextAnalysisService>();
+        services.AddScoped<IUserAiProfileService, Valora.Infrastructure.Services.AppServices.UserAiProfileService>();
+        services.AddScoped<IContextDataProvider, Valora.Infrastructure.Services.AppServices.ContextDataProvider>();
+        services.AddScoped<IMapService, Valora.Infrastructure.Services.AppServices.MapService>();
+        services.AddScoped<IBatchJobService, Valora.Infrastructure.Services.AppServices.BatchJobService>();
+        services.AddScoped<IBatchJobExecutor, Valora.Infrastructure.Services.AppServices.BatchJobExecutor>();
+        services.AddScoped<IWorkspaceService, Valora.Infrastructure.Services.AppServices.WorkspaceService>();
+        services.AddScoped<IWorkspaceMemberService, Valora.Infrastructure.Services.AppServices.WorkspaceMemberService>();
+        services.AddScoped<IWorkspacePropertyService, Valora.Infrastructure.Services.AppServices.WorkspacePropertyService>();
+
+        // Batch Job Processors
+        services.AddScoped<IBatchJobProcessor, Valora.Infrastructure.Services.AppServices.BatchJobs.CityIngestionJobProcessor>();
+        services.AddScoped<IBatchJobProcessor, Valora.Infrastructure.Services.AppServices.BatchJobs.MapGenerationJobProcessor>();
+        services.AddScoped<IBatchJobProcessor, Valora.Infrastructure.Services.AppServices.BatchJobs.AllCitiesIngestionJobProcessor>();
 
         var rawConnectionString = configuration["DATABASE_URL"] ?? configuration.GetConnectionString("DefaultConnection");
         var connectionString = ConnectionStringParser.BuildConnectionString(rawConnectionString);

--- a/backend/Valora.Infrastructure/Services/AppServices/AdminService.cs
+++ b/backend/Valora.Infrastructure/Services/AppServices/AdminService.cs
@@ -4,7 +4,7 @@ using Valora.Application.Common.Models;
 using Valora.Application.DTOs;
 using Valora.Domain.Entities;
 
-namespace Valora.Application.Services;
+namespace Valora.Infrastructure.Services.AppServices;
 
 public class AdminService : IAdminService
 {

--- a/backend/Valora.Infrastructure/Services/AppServices/AuthService.cs
+++ b/backend/Valora.Infrastructure/Services/AppServices/AuthService.cs
@@ -7,7 +7,7 @@ using Valora.Application.Common.Utilities;
 using Valora.Application.DTOs;
 using Valora.Domain.Entities;
 
-namespace Valora.Application.Services;
+namespace Valora.Infrastructure.Services.AppServices;
 
 public class AuthService : IAuthService
 {

--- a/backend/Valora.Infrastructure/Services/AppServices/BatchJobExecutor.cs
+++ b/backend/Valora.Infrastructure/Services/AppServices/BatchJobExecutor.cs
@@ -1,11 +1,11 @@
 using Microsoft.Extensions.Logging;
 using Valora.Application.Common.Interfaces;
-using Valora.Application.Services.BatchJobs;
+using Valora.Infrastructure.Services.AppServices.BatchJobs;
 using Valora.Domain.Entities;
 using Valora.Domain.Enums;
 using Valora.Application.Common.Events;
 
-namespace Valora.Application.Services;
+namespace Valora.Infrastructure.Services.AppServices;
 
 public class BatchJobExecutor : IBatchJobExecutor
 {

--- a/backend/Valora.Infrastructure/Services/AppServices/BatchJobService.cs
+++ b/backend/Valora.Infrastructure/Services/AppServices/BatchJobService.cs
@@ -6,7 +6,7 @@ using Valora.Application.DTOs;
 using Valora.Domain.Entities;
 using Valora.Domain.Enums;
 
-namespace Valora.Application.Services;
+namespace Valora.Infrastructure.Services.AppServices;
 
 public class BatchJobService : IBatchJobService
 {

--- a/backend/Valora.Infrastructure/Services/AppServices/BatchJobs/AllCitiesIngestionJobProcessor.cs
+++ b/backend/Valora.Infrastructure/Services/AppServices/BatchJobs/AllCitiesIngestionJobProcessor.cs
@@ -4,7 +4,7 @@ using Valora.Domain.Entities;
 using Valora.Domain.Enums;
 using Valora.Domain.Extensions;
 
-namespace Valora.Application.Services.BatchJobs;
+namespace Valora.Infrastructure.Services.AppServices.BatchJobs;
 
 public class AllCitiesIngestionJobProcessor : IBatchJobProcessor
 {

--- a/backend/Valora.Infrastructure/Services/AppServices/BatchJobs/CityIngestionJobProcessor.cs
+++ b/backend/Valora.Infrastructure/Services/AppServices/BatchJobs/CityIngestionJobProcessor.cs
@@ -5,7 +5,7 @@ using Valora.Domain.Entities;
 using Valora.Domain.Enums;
 using Valora.Domain.Extensions;
 
-namespace Valora.Application.Services.BatchJobs;
+namespace Valora.Infrastructure.Services.AppServices.BatchJobs;
 
 public class CityIngestionJobProcessor : IBatchJobProcessor
 {

--- a/backend/Valora.Infrastructure/Services/AppServices/BatchJobs/MapGenerationJobProcessor.cs
+++ b/backend/Valora.Infrastructure/Services/AppServices/BatchJobs/MapGenerationJobProcessor.cs
@@ -1,8 +1,9 @@
 using Microsoft.Extensions.Logging;
 using Valora.Domain.Entities;
 using Valora.Domain.Enums;
+using Valora.Application.Common.Interfaces;
 
-namespace Valora.Application.Services.BatchJobs;
+namespace Valora.Infrastructure.Services.AppServices.BatchJobs;
 
 public class MapGenerationJobProcessor : IBatchJobProcessor
 {

--- a/backend/Valora.Infrastructure/Services/AppServices/ContextAnalysisService.cs
+++ b/backend/Valora.Infrastructure/Services/AppServices/ContextAnalysisService.cs
@@ -3,11 +3,11 @@ using Valora.Application.Common.Interfaces;
 using Valora.Application.Common.Events;
 using Valora.Application.Common.Utilities;
 using Valora.Application.DTOs;
-using Valora.Application.Services.Utilities;
+using Valora.Infrastructure.Services.AppServices.Utilities;
 using Valora.Domain.Services;
 using System;
 
-namespace Valora.Application.Services;
+namespace Valora.Infrastructure.Services.AppServices;
 
 public class ContextAnalysisService : IContextAnalysisService
 {

--- a/backend/Valora.Infrastructure/Services/AppServices/ContextDataProvider.cs
+++ b/backend/Valora.Infrastructure/Services/AppServices/ContextDataProvider.cs
@@ -4,7 +4,7 @@ using Valora.Application.Common.Interfaces;
 using Valora.Application.DTOs;
 using Valora.Domain.Common;
 
-namespace Valora.Application.Services;
+namespace Valora.Infrastructure.Services.AppServices;
 
 /// <summary>
 /// Provides data from multiple external sources for context reports.

--- a/backend/Valora.Infrastructure/Services/AppServices/ContextReportService.cs
+++ b/backend/Valora.Infrastructure/Services/AppServices/ContextReportService.cs
@@ -10,7 +10,7 @@ using Valora.Application.Enrichment.Builders;
 using Valora.Domain.Models;
 using Valora.Domain.Services;
 
-namespace Valora.Application.Services;
+namespace Valora.Infrastructure.Services.AppServices;
 
 /// <summary>
 /// Orchestrates the generation of context reports by aggregating data from multiple external sources.

--- a/backend/Valora.Infrastructure/Services/AppServices/MapService.cs
+++ b/backend/Valora.Infrastructure/Services/AppServices/MapService.cs
@@ -5,7 +5,7 @@ using Valora.Application.DTOs.Map;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Logging;
 
-namespace Valora.Application.Services;
+namespace Valora.Infrastructure.Services.AppServices;
 
 public class MapService : IMapService
 {

--- a/backend/Valora.Infrastructure/Services/AppServices/NotificationService.cs
+++ b/backend/Valora.Infrastructure/Services/AppServices/NotificationService.cs
@@ -5,7 +5,7 @@ using Valora.Domain.Common;
 using Valora.Domain.Entities;
 using Valora.Domain.Enums;
 
-namespace Valora.Application.Services;
+namespace Valora.Infrastructure.Services.AppServices;
 
 public class NotificationService : INotificationService
 {

--- a/backend/Valora.Infrastructure/Services/AppServices/UserAiProfileService.cs
+++ b/backend/Valora.Infrastructure/Services/AppServices/UserAiProfileService.cs
@@ -4,7 +4,7 @@ using Valora.Application.Common.Models;
 using Valora.Application.DTOs;
 using Valora.Domain.Entities;
 
-namespace Valora.Application.Services;
+namespace Valora.Infrastructure.Services.AppServices;
 
 public class UserAiProfileService : IUserAiProfileService
 {

--- a/backend/Valora.Infrastructure/Services/AppServices/Utilities/AmenityClusterer.cs
+++ b/backend/Valora.Infrastructure/Services/AppServices/Utilities/AmenityClusterer.cs
@@ -1,6 +1,6 @@
 using Valora.Application.DTOs.Map;
 
-namespace Valora.Application.Services.Utilities;
+namespace Valora.Infrastructure.Services.AppServices.Utilities;
 
 /// <summary>
 /// Provides utility methods for clustering map amenities to prevent client-side rendering bottlenecks.

--- a/backend/Valora.Infrastructure/Services/AppServices/Utilities/ContextReportXmlBuilder.cs
+++ b/backend/Valora.Infrastructure/Services/AppServices/Utilities/ContextReportXmlBuilder.cs
@@ -3,7 +3,7 @@ using Valora.Application.Common.Utilities;
 using Valora.Application.DTOs;
 using Valora.Domain.Services;
 
-namespace Valora.Application.Services.Utilities;
+namespace Valora.Infrastructure.Services.AppServices.Utilities;
 
 internal sealed class ContextReportXmlBuilder
 {

--- a/backend/Valora.Infrastructure/Services/AppServices/Utilities/OverlayRasterizer.cs
+++ b/backend/Valora.Infrastructure/Services/AppServices/Utilities/OverlayRasterizer.cs
@@ -1,7 +1,7 @@
 using Valora.Application.Common.Utilities;
 using Valora.Application.DTOs.Map;
 
-namespace Valora.Application.Services.Utilities;
+namespace Valora.Infrastructure.Services.AppServices.Utilities;
 
 /// <summary>
 /// Provides high-performance spatial rasterization of vector geometries (GeoJSON) into discrete map tiles.

--- a/backend/Valora.Infrastructure/Services/AppServices/Utilities/PriceOverlayCalculator.cs
+++ b/backend/Valora.Infrastructure/Services/AppServices/Utilities/PriceOverlayCalculator.cs
@@ -3,7 +3,7 @@ using Valora.Application.Common.Utilities;
 using Valora.Application.DTOs.Map;
 using Valora.Domain.Entities;
 
-namespace Valora.Application.Services.Utilities;
+namespace Valora.Infrastructure.Services.AppServices.Utilities;
 
 /// <summary>
 /// Provides utility methods for combining real estate price data with geographical map overlays.

--- a/backend/Valora.Infrastructure/Services/AppServices/WorkspaceMemberService.cs
+++ b/backend/Valora.Infrastructure/Services/AppServices/WorkspaceMemberService.cs
@@ -3,7 +3,7 @@ using Valora.Application.Common.Interfaces;
 using Valora.Application.DTOs;
 using Valora.Domain.Entities;
 
-namespace Valora.Application.Services;
+namespace Valora.Infrastructure.Services.AppServices;
 
 public class WorkspaceMemberService : IWorkspaceMemberService
 {

--- a/backend/Valora.Infrastructure/Services/AppServices/WorkspacePropertyService.cs
+++ b/backend/Valora.Infrastructure/Services/AppServices/WorkspacePropertyService.cs
@@ -4,7 +4,7 @@ using Valora.Application.DTOs;
 using Valora.Domain.Entities;
 using Valora.Application.Common.Extensions;
 
-namespace Valora.Application.Services;
+namespace Valora.Infrastructure.Services.AppServices;
 
 public class WorkspacePropertyService : IWorkspacePropertyService
 {

--- a/backend/Valora.Infrastructure/Services/AppServices/WorkspaceService.cs
+++ b/backend/Valora.Infrastructure/Services/AppServices/WorkspaceService.cs
@@ -4,7 +4,7 @@ using Valora.Application.DTOs;
 using Valora.Domain.Entities;
 using Valora.Application.Common.Extensions;
 
-namespace Valora.Application.Services;
+namespace Valora.Infrastructure.Services.AppServices;
 
 public class WorkspaceService : IWorkspaceService
 {

--- a/backend/Valora.Infrastructure/Services/NotificationEventHandlers.cs
+++ b/backend/Valora.Infrastructure/Services/NotificationEventHandlers.cs
@@ -1,10 +1,10 @@
-using Valora.Application.Services;
+using Valora.Infrastructure.Services.AppServices;
+using Valora.Application.Common.Interfaces;
 using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Valora.Application.Common.Events;
-using Valora.Application.Common.Interfaces;
 using Valora.Domain.Enums;
 using Valora.Domain.Entities;
 using System.Linq;

--- a/backend/Valora.IntegrationTests/AiEndpointTests.cs
+++ b/backend/Valora.IntegrationTests/AiEndpointTests.cs
@@ -5,7 +5,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Moq;
 using Valora.Application.Common.Interfaces;
 using Valora.Application.DTOs;
-using Valora.Application.Services;
+using Valora.Infrastructure.Services.AppServices;
 using Xunit;
 
 namespace Valora.IntegrationTests;

--- a/backend/Valora.IntegrationTests/BatchJobExecutorIntegrationTests.cs
+++ b/backend/Valora.IntegrationTests/BatchJobExecutorIntegrationTests.cs
@@ -9,7 +9,7 @@ using Moq;
 using Shouldly;
 using Valora.Application.Common.Events;
 using Valora.Application.Common.Interfaces;
-using Valora.Application.Services.BatchJobs;
+using Valora.Infrastructure.Services.AppServices.BatchJobs;
 using Valora.Domain.Entities;
 using Valora.Infrastructure.Persistence;
 using Xunit;

--- a/backend/Valora.IntegrationTests/ContextAnalysisIntegrationTests.cs
+++ b/backend/Valora.IntegrationTests/ContextAnalysisIntegrationTests.cs
@@ -4,7 +4,7 @@ using Microsoft.Extensions.DependencyInjection.Extensions;
 using Moq;
 using Valora.Application.Common.Interfaces;
 using Valora.Application.DTOs;
-using Valora.Application.Services;
+using Valora.Infrastructure.Services.AppServices;
 using Valora.Domain.Entities;
 using Valora.Infrastructure.Persistence;
 using Xunit;

--- a/backend/Valora.IntegrationTests/ContextAnalysisSessionProfileTests.cs
+++ b/backend/Valora.IntegrationTests/ContextAnalysisSessionProfileTests.cs
@@ -4,7 +4,7 @@ using Microsoft.Extensions.DependencyInjection.Extensions;
 using Moq;
 using Valora.Application.Common.Interfaces;
 using Valora.Application.DTOs;
-using Valora.Application.Services;
+using Valora.Infrastructure.Services.AppServices;
 using Valora.Domain.Entities;
 using Valora.Infrastructure.Persistence;
 using Xunit;

--- a/backend/Valora.UnitTests/Services/AdminServiceTests.cs
+++ b/backend/Valora.UnitTests/Services/AdminServiceTests.cs
@@ -3,7 +3,7 @@ using Moq;
 using Valora.Application.Common.Interfaces;
 using Valora.Application.Common.Models;
 using Valora.Application.DTOs;
-using Valora.Application.Services;
+using Valora.Infrastructure.Services.AppServices;
 using Valora.Domain.Entities;
 using Xunit;
 

--- a/backend/Valora.UnitTests/Services/AuthServiceTests.cs
+++ b/backend/Valora.UnitTests/Services/AuthServiceTests.cs
@@ -5,7 +5,7 @@ using Valora.Application.Common.Constants;
 using Valora.Application.Common.Interfaces;
 using Valora.Application.Common.Models;
 using Valora.Application.DTOs;
-using Valora.Application.Services;
+using Valora.Infrastructure.Services.AppServices;
 using Valora.Domain.Entities;
 
 namespace Valora.UnitTests.Services;

--- a/backend/Valora.UnitTests/Services/BatchJobExecutorTests.cs
+++ b/backend/Valora.UnitTests/Services/BatchJobExecutorTests.cs
@@ -1,8 +1,8 @@
 using Valora.Application.Common.Interfaces;
 using Moq;
 using Microsoft.Extensions.Logging;
-using Valora.Application.Services;
-using Valora.Application.Services.BatchJobs;
+using Valora.Infrastructure.Services.AppServices;
+using Valora.Infrastructure.Services.AppServices.BatchJobs;
 using Valora.Domain.Entities;
 
 namespace Valora.UnitTests.Services;

--- a/backend/Valora.UnitTests/Services/BatchJobServiceGetJobsTests.cs
+++ b/backend/Valora.UnitTests/Services/BatchJobServiceGetJobsTests.cs
@@ -2,7 +2,7 @@ using Microsoft.Extensions.Logging;
 using Moq;
 using Valora.Application.Common.Interfaces;
 using Valora.Application.Common.Models;
-using Valora.Application.Services;
+using Valora.Infrastructure.Services.AppServices;
 using Valora.Domain.Entities;
 
 namespace Valora.UnitTests.Services;

--- a/backend/Valora.UnitTests/Services/BatchJobServiceTests.cs
+++ b/backend/Valora.UnitTests/Services/BatchJobServiceTests.cs
@@ -2,8 +2,8 @@ using Microsoft.Extensions.Logging;
 using Moq;
 using Valora.Application.Common.Interfaces;
 using Valora.Application.DTOs;
-using Valora.Application.Services;
-using Valora.Application.Services.BatchJobs;
+using Valora.Infrastructure.Services.AppServices;
+using Valora.Infrastructure.Services.AppServices.BatchJobs;
 using Valora.Domain.Entities;
 
 namespace Valora.UnitTests.Services;

--- a/backend/Valora.UnitTests/Services/BatchJobs/AllCitiesIngestionJobProcessorTests.cs
+++ b/backend/Valora.UnitTests/Services/BatchJobs/AllCitiesIngestionJobProcessorTests.cs
@@ -1,7 +1,7 @@
 using Microsoft.Extensions.Logging;
 using Moq;
 using Valora.Application.Common.Interfaces;
-using Valora.Application.Services.BatchJobs;
+using Valora.Infrastructure.Services.AppServices.BatchJobs;
 using Valora.Domain.Entities;
 using Xunit;
 

--- a/backend/Valora.UnitTests/Services/BatchJobs/CityIngestionJobProcessorTests.cs
+++ b/backend/Valora.UnitTests/Services/BatchJobs/CityIngestionJobProcessorTests.cs
@@ -3,7 +3,7 @@ using Moq;
 using Valora.Application.Common.Interfaces;
 using Valora.Application.DTOs;
 using Valora.Application.DTOs.Map;
-using Valora.Application.Services.BatchJobs;
+using Valora.Infrastructure.Services.AppServices.BatchJobs;
 using Valora.Domain.Entities;
 
 namespace Valora.UnitTests.Services.BatchJobs;

--- a/backend/Valora.UnitTests/Services/ContextAnalysisServiceTests.cs
+++ b/backend/Valora.UnitTests/Services/ContextAnalysisServiceTests.cs
@@ -1,7 +1,7 @@
 using Moq;
 using Valora.Application.Common.Interfaces;
 using Valora.Application.DTOs;
-using Valora.Application.Services;
+using Valora.Infrastructure.Services.AppServices;
 
 namespace Valora.UnitTests.Services;
 

--- a/backend/Valora.UnitTests/Services/ContextDataProviderTests.cs
+++ b/backend/Valora.UnitTests/Services/ContextDataProviderTests.cs
@@ -2,7 +2,7 @@ using Microsoft.Extensions.Logging;
 using Moq;
 using Valora.Application.Common.Interfaces;
 using Valora.Application.DTOs;
-using Valora.Application.Services;
+using Valora.Infrastructure.Services.AppServices;
 
 namespace Valora.UnitTests.Services;
 

--- a/backend/Valora.UnitTests/Services/ContextReportScoringTests.cs
+++ b/backend/Valora.UnitTests/Services/ContextReportScoringTests.cs
@@ -4,7 +4,7 @@ using Moq;
 using Valora.Application.Common.Interfaces;
 using Valora.Application.DTOs;
 using Valora.Application.Enrichment;
-using Valora.Application.Services;
+using Valora.Infrastructure.Services.AppServices;
 
 namespace Valora.UnitTests.Services;
 

--- a/backend/Valora.UnitTests/Services/ContextReportServiceTests.cs
+++ b/backend/Valora.UnitTests/Services/ContextReportServiceTests.cs
@@ -5,7 +5,7 @@ using Valora.Application.Common.Exceptions;
 using Valora.Application.Common.Interfaces;
 using Valora.Application.DTOs;
 using Valora.Application.Enrichment;
-using Valora.Application.Services;
+using Valora.Infrastructure.Services.AppServices;
 
 namespace Valora.UnitTests.Services;
 

--- a/backend/Valora.UnitTests/Services/MapServiceTests.cs
+++ b/backend/Valora.UnitTests/Services/MapServiceTests.cs
@@ -3,7 +3,7 @@ using Moq;
 using Valora.Application.Common.Exceptions;
 using Valora.Application.Common.Interfaces;
 using Valora.Application.DTOs.Map;
-using Valora.Application.Services;
+using Valora.Infrastructure.Services.AppServices;
 using Xunit;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Logging;

--- a/backend/Valora.UnitTests/Services/NotificationServiceTests.cs
+++ b/backend/Valora.UnitTests/Services/NotificationServiceTests.cs
@@ -6,7 +6,8 @@ using Valora.Infrastructure.Persistence;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Time.Testing;
 using Moq;
-using Valora.Application.Services;
+using Valora.Infrastructure.Services.AppServices;
+using Valora.Application.Common.Interfaces;
 using Valora.Infrastructure.Persistence.Repositories;
 using Xunit;
 

--- a/backend/Valora.UnitTests/Services/SecurityFixTests.cs
+++ b/backend/Valora.UnitTests/Services/SecurityFixTests.cs
@@ -6,7 +6,7 @@ using Moq;
 using Valora.Application.Common.Interfaces;
 using Valora.Application.Common.Utilities;
 using Valora.Application.DTOs;
-using Valora.Application.Services;
+using Valora.Infrastructure.Services.AppServices;
 using Valora.Domain.Entities;
 using Valora.Domain.Services;
 

--- a/backend/Valora.UnitTests/Services/UserAiProfileServiceTests.cs
+++ b/backend/Valora.UnitTests/Services/UserAiProfileServiceTests.cs
@@ -2,7 +2,7 @@ using Moq;
 using Valora.Application.Common.Interfaces;
 using Valora.Application.Common.Models;
 using Valora.Application.DTOs;
-using Valora.Application.Services;
+using Valora.Infrastructure.Services.AppServices;
 using Valora.Domain.Entities;
 
 namespace Valora.UnitTests.Services;

--- a/backend/Valora.UnitTests/Services/Utilities/AmenityClustererTests.cs
+++ b/backend/Valora.UnitTests/Services/Utilities/AmenityClustererTests.cs
@@ -1,5 +1,5 @@
 using Valora.Application.DTOs.Map;
-using Valora.Application.Services.Utilities;
+using Valora.Infrastructure.Services.AppServices.Utilities;
 using Xunit;
 
 namespace Valora.UnitTests.Services.Utilities;

--- a/backend/Valora.UnitTests/Services/Utilities/OverlayRasterizerTests.cs
+++ b/backend/Valora.UnitTests/Services/Utilities/OverlayRasterizerTests.cs
@@ -1,6 +1,6 @@
 using System.Text.Json;
 using Valora.Application.DTOs.Map;
-using Valora.Application.Services.Utilities;
+using Valora.Infrastructure.Services.AppServices.Utilities;
 using Xunit;
 
 namespace Valora.UnitTests.Services.Utilities;

--- a/backend/Valora.UnitTests/Services/Utilities/PriceOverlayCalculatorTests.cs
+++ b/backend/Valora.UnitTests/Services/Utilities/PriceOverlayCalculatorTests.cs
@@ -1,7 +1,7 @@
 using System.Globalization;
 using System.Text.Json;
 using Valora.Application.DTOs.Map;
-using Valora.Application.Services.Utilities;
+using Valora.Infrastructure.Services.AppServices.Utilities;
 using Xunit;
 
 namespace Valora.UnitTests.Services.Utilities;

--- a/backend/Valora.UnitTests/Services/WorkspaceMemberServiceTests.cs
+++ b/backend/Valora.UnitTests/Services/WorkspaceMemberServiceTests.cs
@@ -3,7 +3,7 @@ using Moq;
 using Valora.Application.Common.Exceptions;
 using Valora.Application.Common.Interfaces;
 using Valora.Application.DTOs;
-using Valora.Application.Services;
+using Valora.Infrastructure.Services.AppServices;
 using Valora.Domain.Entities;
 using Valora.Infrastructure.Persistence;
 using Valora.Infrastructure.Persistence.Repositories;

--- a/backend/Valora.UnitTests/Services/WorkspacePropertyServiceTests.cs
+++ b/backend/Valora.UnitTests/Services/WorkspacePropertyServiceTests.cs
@@ -1,7 +1,7 @@
 using Moq;
 using Valora.Application.Common.Interfaces;
 using Valora.Application.Common.Extensions;
-using Valora.Application.Services;
+using Valora.Infrastructure.Services.AppServices;
 using Valora.Domain.Entities;
 using Xunit;
 

--- a/backend/Valora.UnitTests/Services/WorkspaceServiceTests.cs
+++ b/backend/Valora.UnitTests/Services/WorkspaceServiceTests.cs
@@ -9,7 +9,7 @@ using Valora.Application.Common.Interfaces;
 using Valora.Application.DTOs;
 using Valora.Domain.Entities;
 using Valora.Infrastructure.Persistence;
-using Valora.Application.Services;
+using Valora.Infrastructure.Services.AppServices;
 using Valora.Infrastructure.Persistence.Repositories;
 using Xunit;
 


### PR DESCRIPTION
Refactored the codebase to adhere to Clean Architecture principles by separating interfaces from their concrete implementations. The Application layer now only contains interfaces (`Valora.Application.Common.Interfaces`), while the concrete service implementations (`Valora.Infrastructure.Services.AppServices`) reside entirely within the Infrastructure layer. The Dependency Injection configuration has been adjusted accordingly. Tests and Api endpoints were updated to correctly reference the new namespaces. This strictly enforces the rule that the Domain and Application layers do not depend on Infrastructure.

---
*PR created automatically by Jules for task [11222908824748455705](https://jules.google.com/task/11222908824748455705) started by @YKDBontekoe*